### PR TITLE
feat: prepare new api version request payload

### DIFF
--- a/src/agent_scan/models/api/v20260710.py
+++ b/src/agent_scan/models/api/v20260710.py
@@ -16,6 +16,36 @@ from agent_scan.models.mcp import RemoteServer, ServerSignature, StdioServer
 from agent_scan.models.skill import SkillFile
 
 
+def _error_for_request(error: ScanError | None) -> ScanError | None:
+    """Copy an error while keeping machine-local diagnostics off the wire."""
+    if error is None:
+        return None
+
+    # Imported lazily because ``redact`` depends on the public model facade,
+    # which imports this version module while that facade is initialized.
+    from agent_scan.redact import redact_absolute_paths, redact_text
+
+    def sanitize(value: Exception | str | None) -> str | None:
+        if value is None:
+            return None
+        return redact_absolute_paths(redact_text(str(value)))
+
+    sanitized = error.clone()
+    sanitized.message = sanitize(sanitized.message)
+    sanitized.exception = sanitize(sanitized.exception)
+    sanitized.traceback = None
+    sanitized.server_output = sanitize(sanitized.server_output)
+    return sanitized
+
+
+def _server_for_request(server: StdioServer | RemoteServer) -> StdioServer | RemoteServer:
+    """Copy and sanitize a server config without changing local inspect output."""
+    # See the lazy-import note in ``_error_for_request`` above.
+    from agent_scan.redact import redact_server_config
+
+    return redact_server_config(server.model_copy(deep=True))
+
+
 # Request inventory and envelope
 # ------------------------------
 # These are deliberately distinct from the local inspection models. Conversion
@@ -32,9 +62,9 @@ class McpServerRequest(BaseModel):
         return cls(
             name=inspected.name,
             config_path=inspected.config_path,
-            server=inspected.server.model_copy(deep=True),
+            server=_server_for_request(inspected.server),
             signature=inspected.signature.model_copy(deep=True) if inspected.signature else None,
-            error=inspected.error.clone() if inspected.error else None,
+            error=_error_for_request(inspected.error),
         )
 
 
@@ -50,7 +80,7 @@ class SkillRequest(BaseModel):
             name=inspected.name,
             installation_path=inspected.installation_path,
             files=[file.model_copy(deep=True) for file in inspected.files],
-            error=inspected.error.clone() if inspected.error else None,
+            error=_error_for_request(inspected.error),
         )
 
 
@@ -68,7 +98,7 @@ class ScanPathRequest(BaseModel):
             path=inspected.path,
             servers=[McpServerRequest.from_inspected(server) for server in inspected.servers],
             skills=[SkillRequest.from_inspected(skill) for skill in inspected.skills],
-            error=inspected.error.clone() if inspected.error else None,
+            error=_error_for_request(inspected.error),
         )
 
 

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -645,9 +645,36 @@ def redact_signature(signature: ServerSignature) -> ServerSignature:
     return signature
 
 
+def redact_server_config(server: StdioServer | RemoteServer) -> StdioServer | RemoteServer:
+    """Redact sensitive values from an MCP server configuration in place."""
+    if isinstance(server, StdioServer):
+        # Redact all environment variables
+        if server.env:
+            server.env = dict.fromkeys(server.env, REDACTED)
+        # Redact argument values via detect-secrets (plugin-named markers).
+        if server.args:
+            server.args = redact_args(server.args)
+
+    elif isinstance(server, RemoteServer):
+        # Redact all headers
+        if server.headers:
+            server.headers = dict.fromkeys(server.headers, REDACTED)
+        # Redact all query parameter values in the URL
+        try:
+            parts = urlsplit(server.url)
+            if parts.query:
+                qs = parse_qsl(parts.query)
+                redacted_qs = [(key, REDACTED) for key, _value in qs]
+                new_query = urlencode(redacted_qs)
+                server.url = urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
+        except Exception:
+            logger.error("Failed to redact URL: %s", server.url)
+
+    return server
+
+
 def redact_server(server_scan_result: ServerScanResult) -> ServerScanResult:
-    """
-    Redact sensitive information from a server scan result.
+    """Redact sensitive information from a server scan result.
 
     For StdioServer:
     - Redacts all environment variable values
@@ -663,30 +690,8 @@ def redact_server(server_scan_result: ServerScanResult) -> ServerScanResult:
     Returns:
         The same server scan result with sensitive data redacted
     """
-    if isinstance(server_scan_result.server, StdioServer):
-        # Redact all environment variables
-        if server_scan_result.server.env:
-            server_scan_result.server.env = dict.fromkeys(server_scan_result.server.env, REDACTED)
-        # Redact argument values via detect-secrets (plugin-named markers).
-        if server_scan_result.server.args:
-            server_scan_result.server.args = redact_args(server_scan_result.server.args)
-
-    elif isinstance(server_scan_result.server, RemoteServer):
-        # Redact all headers
-        if server_scan_result.server.headers:
-            server_scan_result.server.headers = dict.fromkeys(server_scan_result.server.headers, REDACTED)
-        # Redact all query parameter values in the URL
-        try:
-            parts = urlsplit(server_scan_result.server.url)
-            if parts.query:
-                qs = parse_qsl(parts.query)
-                redacted_qs = [(k, REDACTED) for k, _ in qs]
-                new_query = urlencode(redacted_qs)
-                server_scan_result.server.url = urlunsplit(
-                    (parts.scheme, parts.netloc, parts.path, new_query, parts.fragment)
-                )
-        except Exception:
-            logger.error("Failed to redact URL: %s", server_scan_result.server.url)
+    if isinstance(server_scan_result.server, StdioServer | RemoteServer):
+        server_scan_result.server = redact_server_config(server_scan_result.server)
 
     # Redact traceback in server error
     if server_scan_result.error and server_scan_result.error.traceback:

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -16,8 +16,10 @@ from mcp.types import (
 )
 from yaml.error import YAMLError
 
-from agent_scan.models import ServerSignature, SkillServer
-from agent_scan.redact import redact_signature
+from agent_scan.models.mcp import ServerSignature
+from agent_scan.models.skill import SkillFile, SkillServer
+from agent_scan.redact import redact_signature, redact_text
+from agent_scan.utils import get_relative_path
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +226,71 @@ def traverse_skill_tree(skill_path: str, relative_path: str | None) -> tuple[lis
             )
 
     return prompts, resources, tools
+
+
+def _read_skill_file_content(full_path: str) -> str:
+    """Read one skill file's content for the v2026-07-10 request payload.
+
+    Secrets are redacted in place (this is the single point where the raw files
+    are read for the request). Binary files collapse to the same synthetic hash
+    marker ``traverse_skill_tree`` uses; that marker is self-generated and holds
+    no user content, so it is not run through redaction.
+    """
+    expanded = os.path.expanduser(full_path)
+    try:
+        with open(expanded, encoding="utf-8") as f:
+            return redact_text(f.read()) or ""
+    except UnicodeDecodeError:
+        logger.debug("File %s is not valid UTF-8; treating as binary", get_relative_path(full_path))
+        hasher = hashlib.sha256()
+        with open(expanded, "rb") as f:
+            while chunk := f.read(65536):
+                hasher.update(chunk)
+        return f"{BINARY_FILE_DESCRIPTION_PREFIX}{hasher.hexdigest()}"
+
+
+def collect_skill_files(skill_path: str) -> list[SkillFile]:
+    """Collect all skill files as raw ``SkillFile`` records for the v2026-07-10 API payload.
+
+    Traverses and reads every file within a skill target without requiring legacy wrapper objects:
+    - **Single-file command skills** (a flat ``*.md``): returns a single ``SkillFile``
+      keyed by the file's basename (e.g., ``"deploy.md"``).
+    - **Directory skills** (``<name>/SKILL.md`` + subdirectories and sibling files):
+      walks all files in the directory and returns ``SkillFile`` records keyed by their
+      path relative to the skill root with forward slashes (e.g., ``"SKILL.md"``, ``"scripts/run.py"``).
+      Files are sorted deterministically across platforms.
+
+    **File Content Handling:**
+    - **Text files** (instruction markdown, scripts, configs, assets): UTF-8 text is read
+      and run through secret redaction before being sent to the backend.
+    - **Binary files** (images, archives, compiled binaries): non-UTF-8 binary content is
+      caught gracefully and represented as a synthetic hash marker
+      (``"Binary file. Hash: <sha256_hex_digest>"``), preserving asset tracking without
+      transmitting raw binary payloads.
+    """
+    expanded_path = os.path.expanduser(skill_path)
+    if not os.path.exists(expanded_path):
+        raise FileNotFoundError(f"Skill path does not exist: {skill_path}")
+
+    if os.path.isfile(expanded_path):
+        return [
+            SkillFile(
+                path=os.path.basename(expanded_path),
+                content=_read_skill_file_content(expanded_path),
+            )
+        ]
+
+    if not os.path.isdir(expanded_path):
+        raise ValueError(f"Skill path is not a file or directory: {skill_path}")
+
+    files: list[SkillFile] = []
+    for root, dirs, filenames in os.walk(expanded_path):
+        dirs.sort()  # deterministic traversal order across platforms
+        for filename in sorted(filenames):
+            full_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(full_path, expanded_path).replace(os.path.sep, "/")
+            files.append(SkillFile(path=relative_path, content=_read_skill_file_content(full_path)))
+    return files
 
 
 def inspect_skills_dir(path: str) -> list[tuple[str, SkillServer]]:

--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -4,22 +4,50 @@ import logging
 import os
 import ssl
 import traceback
+from typing import Any
 
 import aiohttp
 import certifi
 import rich
 
-from agent_scan.models import (
+from agent_scan.models.api.common import ScanUserInfo
+from agent_scan.models.api.v20250902 import (
     ScalarToolLabels,
-    ScanError,
     ScanPathResult,
     ScanPathResultsCreate,
-    ScanUserInfo,
 )
+from agent_scan.models.api.v20260710 import ScanRequest
+from agent_scan.models.errors import ScanError
+from agent_scan.models.inspect import InspectedPath
 from agent_scan.utils import get_environment, get_relative_path
 from agent_scan.well_known_clients import get_client_from_path
 
 logger = logging.getLogger(__name__)
+
+
+def build_scan_request(
+    inspected_paths: list[InspectedPath],
+    scan_user_info: ScanUserInfo | None = None,
+    scan_metadata: dict[str, Any] | None = None,
+) -> ScanRequest:
+    """Convert inspection inventory into a v2026-07-10 scan request.
+
+    The versioned API models own the structural conversion from inspection-domain
+    models to wire models. This transport boundary additionally makes each top-level
+    path home-relative. Per-component ``config_path`` and ``installation_path``
+    remain absolute because the backend forwards them to Maverick as the asset
+    location.
+
+    This remains additive: ``analyze_machine`` still sends the legacy payload.
+    """
+    request = ScanRequest.from_inspected_paths(
+        inspected_paths,
+        scan_user_info=scan_user_info,
+        scan_metadata=scan_metadata,
+    )
+    for path_request in request.scan_path_requests:
+        path_request.path = get_relative_path(path_request.path)
+    return request
 
 
 class SnykTokenError(Exception):

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -8,8 +8,16 @@ Code command files are flat ``*.md`` files, so they need their own scanner
 
 from pathlib import Path
 
-from agent_scan.models import SkillServer
-from agent_scan.skill_client import inspect_commands_dir, inspect_skill
+import pytest
+
+from agent_scan.models.skill import SkillServer
+from agent_scan.redact import redact_text
+from agent_scan.skill_client import (
+    BINARY_FILE_DESCRIPTION_PREFIX,
+    collect_skill_files,
+    inspect_commands_dir,
+    inspect_skill,
+)
 from tests.unit._secret_fixtures import synthetic_secret
 
 
@@ -276,3 +284,84 @@ def test_redact_and_skill_client_import_without_cycle():
             text=True,
         )
         assert result.returncode == 0, f"importing {module} first failed:\n{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# collect_skill_files: raw file collection for the v2026-07-10 request payload
+# (unlike inspect_skill, which classifies files into a signature's entities).
+# ---------------------------------------------------------------------------
+
+
+def test_collect_skill_files_single_file_command(tmp_path):
+    cmd = tmp_path / "deploy.md"
+    cmd.write_text("# Deploy\nrun the deploy")
+
+    files = collect_skill_files(str(cmd))
+
+    assert len(files) == 1
+    assert files[0].path == "deploy.md"
+    assert files[0].content == "# Deploy\nrun the deploy"
+
+
+def test_collect_skill_files_directory_relative_paths(tmp_path):
+    skill = tmp_path / "my-skill"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: my-skill\n---\ndo things")
+    (skill / "scripts" / "run.py").write_text("print('hi')")
+    (skill / "reference.md").write_text("# Reference")
+
+    by_path = {f.path: f.content for f in collect_skill_files(str(skill))}
+
+    assert set(by_path) == {"SKILL.md", "reference.md", "scripts/run.py"}
+    # nested files keep a forward-slash, skill-relative path
+    assert by_path["scripts/run.py"] == "print('hi')"
+
+
+def test_collect_skill_files_deterministic_order(tmp_path):
+    skill = tmp_path / "skill"
+    (skill / "a").mkdir(parents=True)
+    (skill / "b").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: s\n---\nx")
+    (skill / "a" / "one.md").write_text("1")
+    (skill / "b" / "two.md").write_text("2")
+
+    assert [f.path for f in collect_skill_files(str(skill))] == ["SKILL.md", "a/one.md", "b/two.md"]
+
+
+def test_collect_skill_files_redacts_secrets(tmp_path):
+    raw = f"api_key = {_FAKE_SKILL_SECRET}\n"
+    cmd = tmp_path / "cmd.md"
+    cmd.write_text(raw)
+
+    files = collect_skill_files(str(cmd))
+
+    assert _FAKE_SKILL_SECRET not in files[0].content
+    # redaction is exactly the shared redact_text applied to the raw content
+    assert files[0].content == redact_text(raw)
+
+
+def test_collect_skill_files_binary_hash_marker(tmp_path):
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: s\n---\nx")
+    (skill / "logo.png").write_bytes(b"\xff\xd8\xff\xe0\x00binary\x00data")
+
+    by_path = {f.path: f.content for f in collect_skill_files(str(skill))}
+
+    assert by_path["logo.png"].startswith(BINARY_FILE_DESCRIPTION_PREFIX)
+
+
+def test_collect_skill_files_non_existent_path_raises(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError):
+        collect_skill_files(str(missing))
+
+
+def test_collect_skill_files_rejects_path_that_is_not_file_or_directory(tmp_path, monkeypatch):
+    special_path = tmp_path / "special"
+    special_path.touch()
+    monkeypatch.setattr("agent_scan.skill_client.os.path.isfile", lambda _path: False)
+    monkeypatch.setattr("agent_scan.skill_client.os.path.isdir", lambda _path: False)
+
+    with pytest.raises(ValueError, match="not a file or directory"):
+        collect_skill_files(str(special_path))

--- a/tests/unit/test_verify_api.py
+++ b/tests/unit/test_verify_api.py
@@ -9,15 +9,18 @@ import aiohttp
 import pytest
 from mcp.types import Implementation, InitializeResult, ServerCapabilities, Tool
 
-from agent_scan.models import (
-    RemoteServer,
-    ScanError,
-    ScanPathResult,
-    ServerScanResult,
-    ServerSignature,
-    StdioServer,
+from agent_scan.models.api.common import ScanUserInfo
+from agent_scan.models.api.v20250902 import ScanPathResult, ServerScanResult
+from agent_scan.models.api.v20260710 import (
+    McpServerRequest,
+    ScanPathRequest,
+    SkillRequest,
 )
-from agent_scan.verify_api import analyze_machine, load_extra_ca_certs, setup_tcp_connector
+from agent_scan.models.errors import ErrorCategory, ScanError
+from agent_scan.models.inspect import InspectedPath, InspectedServer, InspectedSkill
+from agent_scan.models.mcp import RemoteServer, ServerSignature, StdioServer
+from agent_scan.models.skill import SkillFile
+from agent_scan.verify_api import analyze_machine, build_scan_request, load_extra_ca_certs, setup_tcp_connector
 
 
 class TestProxySupport:
@@ -837,3 +840,234 @@ class TestAnalyzeMachineHttpErrors:
         figma, playwright = claude.servers
         assert figma.error is not None and figma.error.category == "server_startup"
         assert playwright.error is not None and playwright.error.category == "analysis_error"
+
+
+class TestBuildScanRequest:
+    """The API boundary turns inspection-domain inventory into v2026-07-10 wire models."""
+
+    def test_maps_mcp_servers_and_skills(self):
+        inspected = InspectedPath(
+            client="cursor",
+            path="/tmp/project",
+            servers=[
+                InspectedServer(
+                    name="sqlite",
+                    config_path="/tmp/project/.mcp.json",
+                    server=StdioServer(command="uvx", args=["sqlite-mcp"], type="stdio"),
+                ),
+                InspectedServer(
+                    name="remote",
+                    config_path="/tmp/project/.mcp.json",
+                    server=RemoteServer(url="https://example.com/mcp", type="http"),
+                ),
+            ],
+            skills=[
+                InspectedSkill(
+                    name="my-skill",
+                    installation_path="/tmp/project/.skills/my-skill",
+                    files=[SkillFile(path="SKILL.md", content="---\nname: my-skill\n---\ndo things")],
+                ),
+            ],
+        )
+
+        req = build_scan_request([inspected])
+
+        assert len(req.scan_path_requests) == 1
+        spr = req.scan_path_requests[0]
+        assert type(spr) is ScanPathRequest
+        assert type(spr.servers[0]) is McpServerRequest
+        assert type(spr.skills[0]) is SkillRequest
+        assert spr.client == "cursor"
+        assert [s.name for s in spr.servers] == ["sqlite", "remote"]
+        assert [s.name for s in spr.skills] == ["my-skill"]
+        # mcp fields carried across
+        assert spr.servers[0].config_path == "/tmp/project/.mcp.json"
+        assert isinstance(spr.servers[0].server, StdioServer)
+        assert isinstance(spr.servers[1].server, RemoteServer)
+        # skill request carries installation_path + files verbatim
+        assert spr.skills[0].installation_path == "/tmp/project/.skills/my-skill"
+        assert [f.path for f in spr.skills[0].files] == ["SKILL.md"]
+
+    def test_top_level_path_is_home_relativized(self):
+        absolute_path = os.path.expanduser("~/project/.mcp.json")
+        inspected = InspectedPath(client=None, path=absolute_path)
+        req = build_scan_request([inspected])
+
+        assert req.scan_path_requests[0].path == "~/project/.mcp.json"
+        assert inspected.path == absolute_path
+
+    def test_passes_through_error_and_empty_name(self):
+        server_error = ScanError(message="boom", category="server_startup")
+        inspected = InspectedPath(
+            client=None,
+            path="/tmp/p",
+            error=ScanError(message="path error", category="parse_error"),
+            servers=[
+                InspectedServer(name="", server=StdioServer(command="x", type="stdio"), error=server_error),
+            ],
+        )
+
+        spr = build_scan_request([inspected]).scan_path_requests[0]
+
+        assert spr.error is not None and spr.error.message == "path error"
+        assert spr.servers[0].name == ""
+        assert spr.servers[0].error == server_error
+        assert spr.servers[0].error is not server_error
+
+    def test_sanitizes_error_diagnostics_without_mutating_local_errors(self):
+        private_path = "/Users/alice/private/diagnostics/error.log"
+        secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+
+        def local_error(message: str, category: ErrorCategory) -> ScanError:
+            return ScanError(
+                message=f"{message}: {private_path}",
+                exception=f"permission denied for {private_path}; token={secret}",
+                traceback=f'File "{private_path}", line 7, in inspect\nValueError: token={secret}',
+                server_output=f"failed to open {private_path}; token={secret}",
+                category=category,
+            )
+
+        path_error = local_error("path failed", "parse_error")
+        server_error = local_error("server failed", "server_startup")
+        skill_error = local_error("skill failed", "skill_scan_error")
+        inspected = InspectedPath(
+            client="cursor",
+            path="/tmp/project",
+            error=path_error,
+            servers=[
+                InspectedServer(
+                    name="server",
+                    server=StdioServer(command="server", type="stdio"),
+                    error=server_error,
+                )
+            ],
+            skills=[InspectedSkill(name="skill", installation_path="/tmp/project/skill", error=skill_error)],
+        )
+
+        request = build_scan_request([inspected])
+
+        request_json = request.model_dump_json()
+        assert private_path not in request_json
+        assert secret not in request_json
+        wire_errors = [
+            request.scan_path_requests[0].error,
+            request.scan_path_requests[0].servers[0].error,
+            request.scan_path_requests[0].skills[0].error,
+        ]
+        assert all(error is not None and error.traceback is None for error in wire_errors)
+        assert wire_errors[0] is not None and wire_errors[0].message.startswith("path failed:")
+        assert wire_errors[1] is not None and wire_errors[1].category == "server_startup"
+        assert wire_errors[2] is not None and wire_errors[2].category == "skill_scan_error"
+
+        # Local inspect output retains full diagnostics for --print-errors.
+        assert path_error.traceback is not None and private_path in path_error.traceback
+        assert server_error.exception is not None and secret in str(server_error.exception)
+        assert skill_error.server_output is not None and secret in skill_error.server_output
+
+    def test_redacts_stdio_server_config_without_mutating_local_inventory(self):
+        secret = "ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+        local_server = StdioServer(
+            command="server",
+            args=["--token", secret, "--mode", "safe"],
+            env={"API_TOKEN": secret, "MODE": "development"},
+            type="stdio",
+        )
+        inspected = InspectedPath(
+            path="/tmp/project",
+            servers=[InspectedServer(name="server", server=local_server)],
+        )
+
+        request_server = build_scan_request([inspected]).scan_path_requests[0].servers[0].server
+
+        assert isinstance(request_server, StdioServer)
+        assert request_server.command == "server"
+        assert request_server.args is not None
+        assert secret not in request_server.args
+        assert request_server.args[-2:] == ["--mode", "safe"]
+        assert request_server.env == {"API_TOKEN": "**REDACTED**", "MODE": "**REDACTED**"}
+        assert local_server.args == ["--token", secret, "--mode", "safe"]
+        assert local_server.env == {"API_TOKEN": secret, "MODE": "development"}
+
+    def test_redacts_remote_server_config_without_mutating_local_inventory(self):
+        local_server = RemoteServer(
+            url="https://example.com/mcp?token=private-token&mode=development",
+            headers={"Authorization": "Bearer private-token", "X-Mode": "development"},
+            type="http",
+        )
+        inspected = InspectedPath(
+            path="/tmp/project",
+            servers=[InspectedServer(name="server", server=local_server)],
+        )
+
+        request_server = build_scan_request([inspected]).scan_path_requests[0].servers[0].server
+
+        assert isinstance(request_server, RemoteServer)
+        assert request_server.url == ("https://example.com/mcp?token=%2A%2AREDACTED%2A%2A&mode=%2A%2AREDACTED%2A%2A")
+        assert request_server.headers == {"Authorization": "**REDACTED**", "X-Mode": "**REDACTED**"}
+        assert local_server.url == "https://example.com/mcp?token=private-token&mode=development"
+        assert local_server.headers == {"Authorization": "Bearer private-token", "X-Mode": "development"}
+
+    def test_signature_passed_through_for_mcp_server(self):
+        signature = ServerSignature(
+            metadata=InitializeResult(
+                protocolVersion="2024-11-05",
+                capabilities=ServerCapabilities(),
+                serverInfo=Implementation(name="server", version="1"),
+            )
+        )
+        server = InspectedServer(
+            name="s",
+            server=StdioServer(command="x", type="stdio"),
+            signature=signature,
+        )
+
+        req = build_scan_request([InspectedPath(client=None, path="/tmp/p", servers=[server])])
+
+        converted_signature = req.scan_path_requests[0].servers[0].signature
+        assert converted_signature == signature
+        assert converted_signature is not signature
+
+    def test_serializes_server_key_not_component(self):
+        inspected = InspectedPath(
+            client=None,
+            path="/tmp/p",
+            servers=[InspectedServer(name="s", server=StdioServer(command="x", type="stdio"))],
+        )
+
+        req = build_scan_request(
+            [inspected], scan_user_info=ScanUserInfo(identifier="u"), scan_metadata={"cli_version": "0.6.0"}
+        )
+        server_dump = req.model_dump()["scan_path_requests"][0]["servers"][0]
+
+        assert "server" in server_dump
+        assert "component" not in server_dump
+        assert '"server"' in req.model_dump_json()
+        assert req.scan_metadata == {"cli_version": "0.6.0"}
+
+    def test_maps_each_path_independently_preserving_order(self):
+        inspected = [
+            InspectedPath(
+                client="cursor",
+                path="/tmp/a",
+                servers=[InspectedServer(name="a-srv", server=StdioServer(command="a", type="stdio"))],
+            ),
+            InspectedPath(
+                client="vscode",
+                path="/tmp/b",
+                skills=[InspectedSkill(name="b-skill", installation_path="/tmp/b/skill")],
+            ),
+        ]
+
+        req = build_scan_request(inspected)
+
+        # order preserved, and each path's servers/skills stay independent
+        assert [p.path for p in req.scan_path_requests] == ["/tmp/a", "/tmp/b"]
+        assert [p.client for p in req.scan_path_requests] == ["cursor", "vscode"]
+        assert [s.name for s in req.scan_path_requests[0].servers] == ["a-srv"]
+        assert req.scan_path_requests[0].skills == []
+        assert req.scan_path_requests[1].servers == []
+        assert [s.name for s in req.scan_path_requests[1].skills] == ["b-skill"]
+
+    def test_empty_inspected_paths(self):
+        req = build_scan_request([])
+        assert req.scan_path_requests == []


### PR DESCRIPTION
Prepare the v2026-07-10 request payload (additive)

Stack: 2nd of the agent-scan v0.6.0 migration, on top of the models PR. Additive and not wired in - the live analyze_machine still sends the legacy 2025-09-02 payload, so no runtime behavior changes.

What's in it

1. build_scan_request(inspected_paths) -> ScanRequest (verify_api.py)
This function prepares the request payload. It's not in use yet.

2. collect_skill_files(skill_path) -> list[SkillFile] (skill_client.py)
Reads a skill's files as raw SkillFiles for the new API: single-file commands → one file (basename); directory skills → every file keyed by its skill-relative path (sorted). Content is secret-redacted via the shared redact_text; binary files collapse to the existing Binary file. Hash: <sha256> marker.

3. Tests for both, added to the existing test_verify_api.py / test_skill_client.py.

Reviewer notes

- The main things to check are the mapping correctness and the anonymization boundary above.
- Redaction happens at collection time in collect_skill_files (single read point), mirroring how inspect_skill already redacts skill content today.