### PR TITLE
feat: refactor inspect command to use new data model

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -33,7 +33,7 @@ from agent_scan.pipelines import (
     PushArgs,
     discover_clients_to_inspect,
     inspect_analyze_push_pipeline,
-    inspect_pipeline_inspected,
+    inspect_pipeline,
 )
 from agent_scan.printer import print_inspected_machine, print_scan_result
 from agent_scan.utils import ensure_unicode_console, get_hostname, get_push_key, parse_headers, suppress_stdout
@@ -773,7 +773,7 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> list[Scan
             do_stdio_handshake=decision.do_stdio_handshake,
         )
     elif mode == "inspect":
-        inspected_paths, _scanned_usernames = await inspect_pipeline_inspected(
+        inspected_paths, _scanned_usernames = await inspect_pipeline(
             inspect_args,
             clients_to_inspect=clients_to_inspect,
             precomputed_scan_path_results=precomputed_scan_path_results,

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -1,7 +1,7 @@
 # fix ssl certificates if custom certificates (i.e. ZScaler) are used
 # as this needs to occur at the beginning of the file, we need to disable the ruff rule
 # ruff: noqa: E402
-from typing import Literal
+from typing import Literal, cast
 
 import truststore
 
@@ -22,6 +22,7 @@ from agent_scan.consent import collect_consent
 from agent_scan.models import (
     FAILURE_CATEGORY_TO_CODE,
     ControlServer,
+    InspectedPath,
     ScanPathResult,
     TokenAndClientInfo,
     TokenAndClientInfoList,
@@ -32,9 +33,9 @@ from agent_scan.pipelines import (
     PushArgs,
     discover_clients_to_inspect,
     inspect_analyze_push_pipeline,
-    inspect_pipeline,
+    inspect_pipeline_inspected,
 )
-from agent_scan.printer import print_scan_result
+from agent_scan.printer import print_inspected_machine, print_scan_result
 from agent_scan.utils import ensure_unicode_console, get_hostname, get_push_key, parse_headers, suppress_stdout
 from agent_scan.version import version_info
 
@@ -681,9 +682,14 @@ async def evo(args):
         rich.print(f"[bold red]Error revoking client_id[/bold red]: {e}")
 
 
-async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> list[ScanPathResult]:
+async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> list[ScanPathResult] | list[InspectedPath]:
     """
     Run the scan/inspect pipeline and return results.
+
+    This is a transitional compatibility dispatcher: ``scan`` still consumes
+    the legacy ``ScanPathResult`` representation, while ``inspect`` has
+    migrated to ``InspectedPath``. The union can be removed once the
+    scan/analyze pipeline no longer uses ``ScanPathResult`` internally.
 
     Flow:
     1. Build InspectArgs from CLI args.
@@ -767,7 +773,7 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> list[Scan
             do_stdio_handshake=decision.do_stdio_handshake,
         )
     elif mode == "inspect":
-        scan_path_results, _scanned_usernames = await inspect_pipeline(
+        inspected_paths, _scanned_usernames = await inspect_pipeline_inspected(
             inspect_args,
             clients_to_inspect=clients_to_inspect,
             precomputed_scan_path_results=precomputed_scan_path_results,
@@ -776,7 +782,7 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> list[Scan
             declined_servers=declined_servers,
             do_stdio_handshake=decision.do_stdio_handshake,
         )
-        return scan_path_results
+        return inspected_paths
     else:
         raise ValueError(f"Unknown mode: {mode}, expected 'scan' or 'inspect'")
 
@@ -796,8 +802,8 @@ def _parse_ignore_codes(args, ci_mode: bool) -> set[str]:
     return ignore_codes
 
 
-def _collect_failure_codes(result: list[ScanPathResult]) -> set[str]:
-    """Collect X00x codes from ScanError failures on paths and servers."""
+def _collect_failure_codes(result: list[ScanPathResult] | list[InspectedPath]) -> set[str]:
+    """Collect X00x codes from operational failures in scan or inspect results."""
     codes: set[str] = set()
     for r in result:
         if r.error and r.error.is_failure:
@@ -805,6 +811,10 @@ def _collect_failure_codes(result: list[ScanPathResult]) -> set[str]:
         for s in r.servers or []:
             if s.error and s.error.is_failure:
                 codes.add(FAILURE_CATEGORY_TO_CODE.get(s.error.category, FAILURE_CATEGORY_TO_CODE[None]))
+        if isinstance(r, InspectedPath):
+            for skill in r.skills:
+                if skill.error and skill.error.is_failure:
+                    codes.add(FAILURE_CATEGORY_TO_CODE.get(skill.error.category, FAILURE_CATEGORY_TO_CODE[None]))
     return codes
 
 
@@ -814,15 +824,18 @@ def _apply_ignore_codes(result: list[ScanPathResult], ignore_codes: set[str]) ->
         scan_result.issues = [i for i in scan_result.issues if i.code not in ignore_codes]
 
 
-def _handle_ci_exit(result: list[ScanPathResult], json_output: bool, ignore_codes: set[str]) -> None:
+def _handle_ci_exit(
+    result: list[ScanPathResult] | list[InspectedPath], json_output: bool, ignore_codes: set[str]
+) -> None:
     """In CI mode, exit with code 1 if any issues or unignored failures remain."""
-    has_issues = any(scan_result.issues for scan_result in result)
+    scan_results = [scan_result for scan_result in result if isinstance(scan_result, ScanPathResult)]
+    has_issues = any(scan_result.issues for scan_result in scan_results)
     failure_codes = _collect_failure_codes(result) - ignore_codes
     if not has_issues and not failure_codes:
         return
 
     if not json_output:
-        issue_codes = {issue.code for scan_result in result for issue in scan_result.issues if issue.code}
+        issue_codes = {issue.code for scan_result in scan_results for issue in scan_result.issues if issue.code}
         all_codes = sorted(issue_codes | failure_codes)
         codes_part = ", ".join(all_codes) if all_codes else "none"
         rich.print(
@@ -846,17 +859,30 @@ async def print_scan_inspect(mode="scan", args=None):
     else:
         result = await run_scan(args, mode=mode)
 
+    # `inspect` produces the v2026-07-10 InspectedPath inventory (no analysis, so
+    # no issues / --ci). `scan` still produces ScanPathResult on the legacy path.
+    if mode == "inspect":
+        inspected_paths = cast("list[InspectedPath]", result)
+        if json_output:
+            print(json.dumps({p.path: p.model_dump(mode="json") for p in inspected_paths}, indent=2))
+        else:
+            print_inspected_machine(inspected_paths, print_errors, full_description, args)
+        if ci_mode:
+            _handle_ci_exit(inspected_paths, json_output, ignore_codes)
+        return
+
+    scan_paths = cast("list[ScanPathResult]", result)
     if ci_mode and ignore_codes:
-        _apply_ignore_codes(result, ignore_codes)
+        _apply_ignore_codes(scan_paths, ignore_codes)
 
     if json_output:
-        result_dict = {r.path: r.model_dump(mode="json") for r in result}
+        result_dict = {r.path: r.model_dump(mode="json") for r in scan_paths}
         print(json.dumps(result_dict, indent=2))
     else:
         print_scan_result(
-            result,
+            scan_paths,
             print_errors,
-            inspect_mode=mode == "inspect",
+            inspect_mode=False,
             internal_issues=verbose,
             full_description=full_description,
             args=args,

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -13,6 +13,9 @@ from agent_scan.models import (
     FileNotFoundConfig,
     InspectedClient,
     InspectedExtensions,
+    InspectedPath,
+    InspectedServer,
+    InspectedSkill,
     RemoteServer,
     ScanError,
     ScanPathResult,
@@ -29,7 +32,7 @@ from agent_scan.models import (
     UserDeclinedError,
 )
 from agent_scan.signed_binary import check_server_signature
-from agent_scan.skill_client import inspect_skill, inspect_skills_dir
+from agent_scan.skill_client import collect_skill_files, inspect_skill, inspect_skills_dir
 from agent_scan.traffic_capture import TrafficCapture
 from agent_scan.well_known_clients import expand_path
 
@@ -363,6 +366,33 @@ async def inspect_client(
     return InspectedClient(name=client.name, client_path=client.client_path, extensions=extensions)
 
 
+def _config_error_to_scan_error(
+    error: FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig | SkillScannError,
+) -> ScanError:
+    """Normalize a config-level inspection error for either result model."""
+    return ScanError(
+        message=error.message,
+        exception=error.sub_exception_message,
+        traceback=error.traceback,
+        is_failure=error.is_failure,
+        category=error.category,
+    )
+
+
+def _join_scan_errors(errors: list[ScanError]) -> ScanError | None:
+    """Combine config-level errors into the single error carried by a path."""
+    if not errors:
+        return None
+    error_category = next((error.category for error in errors if error.category is not None), None)
+    return ScanError(
+        message="\n".join(error.message or "" for error in errors),
+        exception="\n".join(str(error.exception) for error in errors),
+        traceback="\n".join(error.traceback or "missing traceback" for error in errors),
+        is_failure=any(error.is_failure for error in errors),
+        category=error_category,
+    )
+
+
 def inspected_client_to_scan_path_result(inspected_client: InspectedClient) -> ScanPathResult:
     """
     Convert a InspectedClient object to a ScanPathResult object.
@@ -373,15 +403,7 @@ def inspected_client_to_scan_path_result(inspected_client: InspectedClient) -> S
         if isinstance(
             extensions_or_error, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig | SkillScannError
         ):
-            candidate_errors.append(
-                ScanError(
-                    message=extensions_or_error.message,
-                    exception=extensions_or_error.sub_exception_message,
-                    traceback=extensions_or_error.traceback,
-                    is_failure=extensions_or_error.is_failure,
-                    category=extensions_or_error.category,
-                )
-            )
+            candidate_errors.append(_config_error_to_scan_error(extensions_or_error))
             continue
         for extension in extensions_or_error:
             if isinstance(extension.signature_or_error, ServerSignature):
@@ -425,21 +447,95 @@ def inspected_client_to_scan_path_result(inspected_client: InspectedClient) -> S
                         ),
                     )
                 )
-    joined_error: None | ScanError = None
-    if len(candidate_errors) > 0:
-        error_category = next((error.category for error in candidate_errors if error.category is not None), None)
-        joined_error = ScanError(
-            message="\n".join([error.message or "" for error in candidate_errors]),
-            exception="\n".join([str(error.exception) for error in candidate_errors]),
-            traceback="\n".join([error.traceback or "missing traceback" for error in candidate_errors]),
-            is_failure=any(error.is_failure for error in candidate_errors),
-            category=error_category,
-        )
     return ScanPathResult(
         client=inspected_client.name,
         path=inspected_client.client_path,
         servers=servers,
         issues=[],
         labels=[],
-        error=joined_error,
+        error=_join_scan_errors(candidate_errors),
+    )
+
+
+def _signature_or_error_to_scan_error(
+    signature_or_error: ServerSignature
+    | ServerStartupError
+    | ServerHTTPError
+    | SkillScannError
+    | UserDeclinedError
+    | None,
+) -> ScanError | None:
+    """Turn an inspected extension's ``signature_or_error`` into a ``ScanError`` if it
+    is an error (``None`` when it is a signature or a not-inspected placeholder)."""
+    if isinstance(signature_or_error, ServerSignature) or signature_or_error is None:
+        return None
+    return ScanError(
+        message=signature_or_error.message,
+        exception=signature_or_error.sub_exception_message,
+        traceback=signature_or_error.traceback,
+        is_failure=signature_or_error.is_failure,
+        category=signature_or_error.category,
+        server_output=signature_or_error.server_output
+        if isinstance(signature_or_error, ServerStartupError | ServerHTTPError)
+        else None,
+    )
+
+
+def inspected_client_to_inspected_path(inspected_client: InspectedClient) -> InspectedPath:
+    """Convert an ``InspectedClient`` into an ``InspectedPath`` (the v2026-07-10 inventory).
+
+    Sibling to :func:`inspected_client_to_scan_path_result` (which stays for the ``scan``
+    path). MCP servers and skills remain inspection-domain models; conversion to
+    versioned API request models happens later at the API boundary.
+    """
+    servers: list[InspectedServer] = []
+    skills: list[InspectedSkill] = []
+    candidate_errors: list[ScanError] = []
+    for config_path, extensions_or_error in inspected_client.extensions.items():
+        if isinstance(
+            extensions_or_error, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig | SkillScannError
+        ):
+            candidate_errors.append(_config_error_to_scan_error(extensions_or_error))
+            continue
+        for extension in extensions_or_error:
+            error = _signature_or_error_to_scan_error(extension.signature_or_error)
+            if isinstance(extension.config, SkillServer):
+                files = []
+                if error is None:
+                    try:
+                        files = collect_skill_files(extension.config.path)
+                    except Exception as collection_error:
+                        error = ScanError(
+                            message="could not collect skill files",
+                            exception=str(collection_error),
+                            traceback=traceback.format_exc(),
+                            is_failure=True,
+                            category="skill_scan_error",
+                        )
+                skills.append(
+                    InspectedSkill(
+                        name=extension.name,
+                        installation_path=extension.config.path,
+                        files=files,
+                        error=error,
+                    )
+                )
+            else:
+                servers.append(
+                    InspectedServer(
+                        name=extension.name,
+                        config_path=config_path,
+                        server=extension.config,
+                        signature=extension.signature_or_error
+                        if isinstance(extension.signature_or_error, ServerSignature)
+                        else None,
+                        error=error,
+                    )
+                )
+    return InspectedPath(
+        client=inspected_client.name,
+        path=inspected_client.client_path,
+        servers=servers,
+        skills=skills,
+        error=_join_scan_errors(candidate_errors),
     )

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -135,7 +135,7 @@ async def discover_clients_to_inspect(
     return clients_to_inspect, scan_path_results, scanned_usernames
 
 
-async def inspect_pipeline(
+async def inspect_legacy_pipeline(
     inspect_args: InspectArgs,
     *,
     clients_to_inspect: list[ClientToInspect] | None = None,
@@ -168,7 +168,7 @@ async def inspect_pipeline(
     return scan_path_results, scanned_usernames or []
 
 
-async def inspect_pipeline_inspected(
+async def inspect_pipeline(
     inspect_args: InspectArgs,
     *,
     clients_to_inspect: list[ClientToInspect] | None = None,
@@ -178,12 +178,12 @@ async def inspect_pipeline_inspected(
     declined_servers: set[tuple[str, str]] | None = None,
     do_stdio_handshake: bool = False,
 ) -> tuple[list[InspectedPath], list[str]]:
-    """Inspect each discovered client and return the v2026-07-10 ``InspectedPath`` inventory.
+    """Inspect each discovered client and return the ``InspectedPath`` inventory.
 
-    The ``InspectedPath`` sibling of :func:`inspect_pipeline`, used by the ``inspect``
-    command. ``scan`` still uses :func:`inspect_pipeline` (``ScanPathResult``). The
-    precomputed results are error-only paths (e.g. file-not-found), so their error is
-    carried straight onto an otherwise-empty ``InspectedPath``.
+    The legacy scan flow still uses :func:`inspect_legacy_pipeline` to produce
+    ``ScanPathResult`` objects. Precomputed results are error-only paths (e.g.
+    file-not-found), so their error is carried straight onto an otherwise-empty
+    ``InspectedPath``.
     """
     if clients_to_inspect is None:
         clients_to_inspect, precomputed_scan_path_results, scanned_usernames = await discover_clients_to_inspect(
@@ -223,7 +223,7 @@ async def inspect_analyze_push_pipeline(
     Pipeline the scan and analyze the machine.
     """
     # inspect
-    scan_path_results, scanned_usernames = await inspect_pipeline(
+    scan_path_results, scanned_usernames = await inspect_legacy_pipeline(
         inspect_args,
         clients_to_inspect=clients_to_inspect,
         precomputed_scan_path_results=precomputed_scan_path_results,

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -10,12 +10,14 @@ from agent_scan.direct_scanner import direct_scan_to_server_config, is_direct_sc
 from agent_scan.inspect import (
     get_mcp_config_per_client,
     inspect_client,
+    inspected_client_to_inspected_path,
     inspected_client_to_scan_path_result,
 )
 from agent_scan.models import (
     CandidateClient,
     ClientToInspect,
     ControlServer,
+    InspectedPath,
     ScanError,
     ScanPathResult,
     SkillServer,
@@ -164,6 +166,44 @@ async def inspect_pipeline(
         )
         scan_path_results.append(inspected_client_to_scan_path_result(inspected_client))
     return scan_path_results, scanned_usernames or []
+
+
+async def inspect_pipeline_inspected(
+    inspect_args: InspectArgs,
+    *,
+    clients_to_inspect: list[ClientToInspect] | None = None,
+    precomputed_scan_path_results: list[ScanPathResult] | None = None,
+    scanned_usernames: list[str] | None = None,
+    stream_stderr: bool = False,
+    declined_servers: set[tuple[str, str]] | None = None,
+    do_stdio_handshake: bool = False,
+) -> tuple[list[InspectedPath], list[str]]:
+    """Inspect each discovered client and return the v2026-07-10 ``InspectedPath`` inventory.
+
+    The ``InspectedPath`` sibling of :func:`inspect_pipeline`, used by the ``inspect``
+    command. ``scan`` still uses :func:`inspect_pipeline` (``ScanPathResult``). The
+    precomputed results are error-only paths (e.g. file-not-found), so their error is
+    carried straight onto an otherwise-empty ``InspectedPath``.
+    """
+    if clients_to_inspect is None:
+        clients_to_inspect, precomputed_scan_path_results, scanned_usernames = await discover_clients_to_inspect(
+            inspect_args
+        )
+    inspected_paths: list[InspectedPath] = [
+        InspectedPath(client=r.client, path=r.path, error=r.error) for r in (precomputed_scan_path_results or [])
+    ]
+    for client_to_inspect in clients_to_inspect:
+        inspected_client = await inspect_client(
+            client_to_inspect,
+            inspect_args.timeout,
+            inspect_args.tokens,
+            inspect_args.scan_skills,
+            stream_stderr=stream_stderr,
+            declined_servers=declined_servers,
+            do_stdio_handshake=do_stdio_handshake,
+        )
+        inspected_paths.append(inspected_client_to_inspected_path(inspected_client))
+    return inspected_paths, scanned_usernames or []
 
 
 async def inspect_analyze_push_pipeline(

--- a/src/agent_scan/printer.py
+++ b/src/agent_scan/printer.py
@@ -10,9 +10,11 @@ from rich.tree import Tree
 from agent_scan.models import (
     FAILURE_CATEGORY_TO_CODE,
     Entity,
+    InspectedPath,
     Issue,
     ScanError,
     ScanPathResult,
+    SkillFile,
     ToxicFlowExtraData,
 )
 
@@ -392,5 +394,119 @@ def print_scan_result(
     for i, path_result in enumerate(result):
         print_scan_path_result(path_result, print_errors, inspect_mode, full_description, args)
         if i < len(result) - 1:
+            rich.print()
+
+
+# ---------------------------------------------------------------------------
+# InspectedPath rendering for the `inspect` command (v2026-07-10 inventory).
+# `inspect` never analyzes, so there are no risks/issues here - just the
+# discovered MCP servers (with their tool/prompt/resource entities) and skills
+# (with their files).
+# ---------------------------------------------------------------------------
+
+
+def _skill_file_type(path: str) -> str:
+    """Human label for a skill file, mirroring ``format_entity_type``'s skill names."""
+    lowered = path.lower()
+    if lowered.endswith(".md"):
+        return "instruction"
+    if lowered.rsplit(".", 1)[-1] in ("py", "js", "ts", "sh"):
+        return "script"
+    return "asset"
+
+
+def format_skill_file_line(skill_file: SkillFile, full_description: bool = False) -> Text:
+    name = skill_file.path
+    if not full_description:
+        name = name + " " * max(0, MAX_ENTITY_NAME_LENGTH_SKILL - len(name))
+    type_str = _skill_file_type(skill_file.path)
+    type_str = type_str + " " * (len("instruction") + 1 - len(type_str))
+    result = Text(type_str)
+    result.append(name, style="bold")
+    return result
+
+
+def print_inspected_path(
+    path: InspectedPath,
+    print_errors: bool = False,
+    full_description: bool = False,
+    args=None,
+) -> None:
+    issues = []
+    if path.error is not None:
+        error_issue, traceback = format_error(path.error)
+        issues.append(error_issue)
+        if print_errors and traceback is not None:
+            rich.console.Console().print(traceback)
+
+    server_count = len(path.servers)
+    skill_count = len(path.skills)
+    report_skills = hasattr(args, "skills") and args.skills
+    if server_count > 0 and skill_count > 0:
+        message = f"found {server_count} mcp server{'' if server_count == 1 else 's'} and {skill_count} skill{'' if skill_count == 1 else 's'}"
+    elif server_count > 0:
+        message = f"found {server_count} mcp server{'' if server_count == 1 else 's'}"
+    elif skill_count > 0:
+        message = f"found {skill_count} skill{'' if skill_count == 1 else 's'}"
+    elif report_skills:
+        message = "no mcp servers or skills found"
+    else:
+        message = "no mcp servers found"
+    rich.print(format_path_line(path.path, message, issues))
+
+    tree = Tree("│")
+    tracebacks: list[tuple[str, rTraceback]] = []
+    for server in path.servers:
+        server_issues = []
+        severities: list[Literal["info", "low", "medium", "high", "critical"]] | None = None
+        if server.error is not None:
+            error_issue, traceback = format_error(server.error)
+            server_issues.append(error_issue)
+            severities = ["info"]
+            if traceback is not None:
+                tracebacks.append((server.name, traceback))
+        server_print = tree.add(format_servers_line(server.name, severities, server_issues))
+        entities = server.signature.entities if server.signature is not None else []
+        for entity in entities:
+            server_print.add(
+                format_entity_line(entity, [], inspect_mode=True, is_skill=False, full_description=full_description)
+            )
+    for skill in path.skills:
+        skill_issues = []
+        severities = None
+        if skill.error is not None:
+            error_issue, traceback = format_error(skill.error)
+            skill_issues.append(error_issue)
+            severities = ["info"]
+            if traceback is not None:
+                tracebacks.append((skill.name, traceback))
+        skill_print = tree.add(format_servers_line(skill.name, severities, skill_issues))
+        for skill_file in skill.files:
+            skill_print.add(format_skill_file_line(skill_file, full_description))
+
+    if server_count > 0 or skill_count > 0:
+        rich.print(tree)
+
+    if print_errors and tracebacks:
+        console = rich.console.Console()
+        for name, traceback in tracebacks:
+            console.print()
+            console.print(f"[bold]Exception when scanning {name}[/bold]")
+            console.print(traceback)
+    print(end="", flush=True)
+
+
+def print_inspected_machine(
+    paths: list[InspectedPath],
+    print_errors: bool = False,
+    full_description: bool = False,
+    args=None,
+) -> None:
+    if not paths:
+        rich.print("No MCP client configurations found on this machine.")
+        return
+    for i, path in enumerate(paths):
+        print_inspected_path(path, print_errors, full_description, args)
+        if i < len(paths) - 1:
             rich.print()
     print(end="", flush=True)

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -271,6 +271,8 @@ def collect_skill_files(skill_path: str) -> list[SkillFile]:
     expanded_path = os.path.expanduser(skill_path)
     if not os.path.exists(expanded_path):
         raise FileNotFoundError(f"Skill path does not exist: {skill_path}")
+    if os.path.islink(expanded_path):
+        raise ValueError("Skill path must not be a symbolic link")
 
     if os.path.isfile(expanded_path):
         return [
@@ -286,8 +288,12 @@ def collect_skill_files(skill_path: str) -> list[SkillFile]:
     files: list[SkillFile] = []
     for root, dirs, filenames in os.walk(expanded_path):
         dirs.sort()  # deterministic traversal order across platforms
+        if any(os.path.islink(os.path.join(root, dirname)) for dirname in dirs):
+            raise ValueError("Skill directory must not contain symbolic links")
         for filename in sorted(filenames):
             full_path = os.path.join(root, filename)
+            if os.path.islink(full_path):
+                raise ValueError("Skill directory must not contain symbolic links")
             relative_path = os.path.relpath(full_path, expanded_path).replace(os.path.sep, "/")
             files.append(SkillFile(path=relative_path, content=_read_skill_file_content(full_path)))
     return files

--- a/tests/e2e/test_inspect.py
+++ b/tests/e2e/test_inspect.py
@@ -2,6 +2,9 @@
 
 import json
 import subprocess
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import PurePosixPath, PureWindowsPath
 
 import pytest
@@ -13,6 +16,74 @@ from agent_scan.utils import TempFile
 def posix(path: str) -> str:
     """Normalize a path to forward slashes so it matches the scanner's JSON output keys."""
     return PurePosixPath(PureWindowsPath(path)).as_posix()
+
+
+def inspect_json(agent_scan_cmd, *args: str, input_text: str | None = None) -> tuple[subprocess.CompletedProcess, dict]:
+    result = subprocess.run(
+        [*agent_scan_cmd, "inspect", "--json", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+    )
+    output = json.loads(result.stdout) if result.stdout.strip() else {}
+    return result, output
+
+
+def only_result(output: dict) -> dict:
+    assert len(output) == 1, f"Expected exactly one inspected path, got: {output}"
+    return next(iter(output.values()))
+
+
+class _ErrorResponseHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(500)
+        self.end_headers()
+
+    def do_POST(self):
+        self.send_response(500)
+        self.end_headers()
+
+    def log_message(self, _format, *args):
+        pass
+
+
+class _SlowResponseHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        time.sleep(2)
+        self.send_response(200)
+        self.end_headers()
+
+    def do_POST(self):
+        time.sleep(2)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, _format, *args):
+        pass
+
+
+@pytest.fixture
+def http_error_server():
+    server = HTTPServer(("127.0.0.1", 0), _ErrorResponseHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/mcp"
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+@pytest.fixture
+def slow_http_server():
+    server = HTTPServer(("127.0.0.1", 0), _SlowResponseHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/mcp"
+    finally:
+        server.shutdown()
+        thread.join()
 
 
 class TestInspect:
@@ -143,12 +214,15 @@ class TestInspect:
         assert result.returncode == 0, f"Command failed with error: {result.stderr}"
         output = json.loads(result.stdout)
         assert len(output) >= 1, "Output should contain at least one entry"
-        all_servers = [server for entry in output.values() for server in entry["servers"]]
-        skill_servers = [s for s in all_servers if s["server"]["type"] == "skill"]
-        assert len(skill_servers) >= 1, f"Expected at least one skill server, got: {output}"
-        assert any(s["name"] == "test-skill" for s in skill_servers), (
-            f"Expected a skill server named 'test-skill', got: {[s['name'] for s in skill_servers]}"
+        all_skills = [skill for entry in output.values() for skill in entry["skills"]]
+        assert len(all_skills) >= 1, f"Expected at least one skill, got: {output}"
+        assert any(s["name"] == "test-skill" for s in all_skills), (
+            f"Expected a skill named 'test-skill', got: {[s['name'] for s in all_skills]}"
         )
+        test_skill = next(s for s in all_skills if s["name"] == "test-skill")
+        assert [file["path"] for file in test_skill["files"]] == ["SKILL.md"]
+        assert "# Test skill" in test_skill["files"][0]["content"]
+        assert test_skill["error"] is None
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     @pytest.mark.parametrize(
@@ -169,11 +243,8 @@ class TestInspect:
         )
         assert result.returncode == 0, f"Command failed with error: {result.stderr}"
         output = json.loads(result.stdout)
-        all_servers = [server for entry in output.values() for server in entry["servers"]]
-        skill_servers = [s for s in all_servers if s["server"]["type"] == "skill"]
-        assert len(skill_servers) == 0, (
-            f"Expected no skill servers without --skills flag, got: {[s['name'] for s in skill_servers]}"
-        )
+        all_skills = [skill for entry in output.values() for skill in entry["skills"]]
+        assert len(all_skills) == 0, f"Expected no skills without --skills flag, got: {[s['name'] for s in all_skills]}"
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     @pytest.mark.parametrize(
@@ -285,3 +356,418 @@ class TestInspect:
             assert posix(vscode_settings_no_mcp_file) in output
         except json.JSONDecodeError:
             pytest.fail("Failed to parse JSON output")
+
+
+class TestInspectBehaviorContract:
+    """Black-box coverage for inspect output, errors, exit codes, and flags."""
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_missing_path_is_non_failing_file_not_found(self, agent_scan_cmd, tmp_path):
+        missing = tmp_path / "missing.json"
+
+        result, output = inspect_json(agent_scan_cmd, "--dangerously-run-mcp-servers", str(missing))
+
+        assert result.returncode == 0
+        error = only_result(output)["error"]
+        assert error["category"] == "file_not_found"
+        assert error["is_failure"] is False
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_malformed_config_is_parse_error(self, agent_scan_cmd, tmp_path):
+        malformed = tmp_path / "malformed.json"
+        malformed.write_text('{"mcpServers": {')
+
+        result, output = inspect_json(agent_scan_cmd, "--dangerously-run-mcp-servers", str(malformed))
+
+        assert result.returncode == 0
+        error = only_result(output)["error"]
+        assert error["category"] == "parse_error"
+        assert error["is_failure"] is True
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_unknown_config_is_non_failing(self, agent_scan_cmd, tmp_path):
+        unknown = tmp_path / "unknown.json"
+        unknown.write_text('{"mcp": []}')
+
+        result, output = inspect_json(agent_scan_cmd, "--dangerously-run-mcp-servers", str(unknown))
+
+        assert result.returncode == 0
+        error = only_result(output)["error"]
+        assert error["category"] == "unknown_config"
+        assert error["is_failure"] is False
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_server_startup_failure_is_attached_to_server(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "broken.json"
+        config.write_text(json.dumps({"mcpServers": {"broken": {"command": "/definitely/not/a/server"}}}))
+
+        result, output = inspect_json(agent_scan_cmd, "--dangerously-run-mcp-servers", str(config))
+
+        assert result.returncode == 0
+        inspected = only_result(output)
+        assert inspected["error"] is None
+        assert inspected["servers"][0]["error"]["category"] == "server_startup"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_http_failure_is_reported_as_server_startup(self, agent_scan_cmd, tmp_path, http_error_server):
+        config = tmp_path / "http-error.json"
+        config.write_text(json.dumps({"mcp": {"servers": {"broken-http": {"type": "http", "url": http_error_server}}}}))
+
+        result, output = inspect_json(agent_scan_cmd, "--dangerously-run-mcp-servers", str(config))
+
+        assert result.returncode == 0
+        # check_server tries several transport/URL strategies and aggregates
+        # their HTTP errors, so the established CLI category is server_startup.
+        assert only_result(output)["servers"][0]["error"]["category"] == "server_startup"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_server_timeout_is_reported_without_aborting_inspect(self, agent_scan_cmd, tmp_path, slow_http_server):
+        config = tmp_path / "slow.json"
+        config.write_text(json.dumps({"mcp": {"servers": {"slow-http": {"type": "http", "url": slow_http_server}}}}))
+
+        result, output = inspect_json(
+            agent_scan_cmd,
+            "--dangerously-run-mcp-servers",
+            "--server-timeout",
+            "1",
+            str(config),
+        )
+
+        assert result.returncode == 0
+        assert only_result(output)["servers"][0]["error"]["category"] == "server_startup"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    @pytest.mark.parametrize(
+        "config_content, expected_code, ignored_code",
+        [
+            ('{"mcpServers": {', "X005", "X005"),
+            (json.dumps({"mcpServers": {"broken": {"command": "/definitely/not/a/server"}}}), "X001", "X001"),
+        ],
+        ids=["parse_error", "server_startup"],
+    )
+    def test_ci_fails_for_operational_errors_and_honors_ignore(
+        self, agent_scan_cmd, tmp_path, config_content, expected_code, ignored_code
+    ):
+        config = tmp_path / "failure.json"
+        config.write_text(config_content)
+
+        failed, _ = inspect_json(
+            agent_scan_cmd,
+            "--ci",
+            "--dangerously-run-mcp-servers",
+            str(config),
+        )
+        ignored, _ = inspect_json(
+            agent_scan_cmd,
+            "--ci",
+            "--ignore-issues-codes",
+            ignored_code,
+            "--dangerously-run-mcp-servers",
+            str(config),
+        )
+
+        assert failed.returncode == 1, f"Expected {expected_code} to fail CI: {failed.stderr}"
+        assert ignored.returncode == 0, f"Expected {ignored_code} to be ignored: {ignored.stderr}"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_rich_ci_prints_failure_code_before_exit(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "broken.json"
+        config.write_text(json.dumps({"mcpServers": {"broken": {"command": "/definitely/not/a/server"}}}))
+
+        result = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "inspect",
+                "--ci",
+                "--dangerously-run-mcp-servers",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert "broken" in result.stdout
+        assert "CI (--ci): exiting with code 1" in result.stderr
+        assert "X001" in result.stderr
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    @pytest.mark.parametrize("kind", ["missing", "unknown"])
+    def test_ci_does_not_fail_for_non_failure_discovery_results(self, agent_scan_cmd, tmp_path, kind):
+        path = tmp_path / "config.json"
+        if kind == "unknown":
+            path.write_text('{"mcp": []}')
+
+        result, _ = inspect_json(
+            agent_scan_cmd,
+            "--ci",
+            "--dangerously-run-mcp-servers",
+            str(path),
+        )
+
+        assert result.returncode == 0
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_ci_requires_dangerous_flag(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "config.json"
+        config.write_text('{"unrelated": true}')
+
+        result, _ = inspect_json(agent_scan_cmd, "--ci", str(config))
+
+        assert result.returncode == 2
+        assert "--ci requires --dangerously-run-mcp-servers" in result.stderr
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_ignore_codes_requires_ci(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "config.json"
+        config.write_text('{"unrelated": true}')
+
+        result, _ = inspect_json(
+            agent_scan_cmd,
+            "--ignore-issues-codes",
+            "X001",
+            "--dangerously-run-mcp-servers",
+            str(config),
+        )
+
+        assert result.returncode == 2
+        assert "--ignore-issues-codes can only be used with --ci" in result.stderr
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_skill_failure_is_reported_and_obeys_ci(self, agent_scan_cmd, tmp_path):
+        skill = tmp_path / "broken-skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_bytes(b"\xff\xfeinvalid utf-8")
+
+        normal, output = inspect_json(
+            agent_scan_cmd,
+            "--skills",
+            "--dangerously-run-mcp-servers",
+            str(skill),
+        )
+        failed, _ = inspect_json(
+            agent_scan_cmd,
+            "--skills",
+            "--ci",
+            "--dangerously-run-mcp-servers",
+            str(skill),
+        )
+        ignored, _ = inspect_json(
+            agent_scan_cmd,
+            "--skills",
+            "--ci",
+            "--ignore-issues-codes",
+            "X002",
+            "--dangerously-run-mcp-servers",
+            str(skill),
+        )
+
+        assert normal.returncode == 0
+        skill_result = only_result(output)["skills"][0]
+        assert skill_result["error"]["category"] == "skill_scan_error"
+        assert failed.returncode == 1
+        assert ignored.returncode == 0
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_symlinked_skill_file_is_reported_as_skill_error(self, agent_scan_cmd, tmp_path):
+        outside = tmp_path / "outside.txt"
+        outside.write_text("must not be collected")
+        skill = tmp_path / "skill"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("---\nname: safe-skill\ndescription: safe\n---\n# Safe instructions")
+        (skill / "outside.txt").symlink_to(outside)
+
+        result, output = inspect_json(
+            agent_scan_cmd,
+            "--skills",
+            "--dangerously-run-mcp-servers",
+            str(skill),
+        )
+
+        assert result.returncode == 0
+        inspected_skill = only_result(output)["skills"][0]
+        assert inspected_skill["files"] == []
+        assert inspected_skill["error"]["category"] == "skill_scan_error"
+        assert "must not contain symbolic links" in inspected_skill["error"]["exception"]
+        assert "ValueError: Skill directory must not contain symbolic links" in inspected_skill["error"]["traceback"]
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_multiple_paths_preserve_success_and_failure_results(self, agent_scan_cmd, tmp_path):
+        unknown = tmp_path / "unknown.json"
+        unknown.write_text('{"mcp": []}')
+        missing = tmp_path / "missing.json"
+
+        result, output = inspect_json(
+            agent_scan_cmd,
+            "--dangerously-run-mcp-servers",
+            str(unknown),
+            str(missing),
+        )
+
+        assert result.returncode == 0
+        assert set(output) == {posix(str(unknown)), posix(str(missing))}
+        assert output[posix(str(unknown))]["error"]["category"] == "unknown_config"
+        assert output[posix(str(missing))]["error"]["category"] == "file_not_found"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_rich_output_and_print_errors(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "broken.json"
+        config.write_text(json.dumps({"mcpServers": {"broken": {"command": "/definitely/not/a/server"}}}))
+
+        concise = subprocess.run(
+            [*agent_scan_cmd, "inspect", "--dangerously-run-mcp-servers", str(config)],
+            capture_output=True,
+            text=True,
+        )
+        detailed = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "inspect",
+                "--dangerously-run-mcp-servers",
+                "--print-errors",
+                "--print-full-descriptions",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert concise.returncode == detailed.returncode == 0
+        assert "broken" in concise.stdout
+        assert "Traceback" not in concise.stdout
+        assert "Exception when scanning broken" in detailed.stdout
+        assert "Traceback" in detailed.stdout
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    @pytest.mark.parametrize("suppress, expect_tip", [("true", False), ("false", True)])
+    def test_suppress_mcpserver_io_controls_dangerous_warning(self, agent_scan_cmd, tmp_path, suppress, expect_tip):
+        config = tmp_path / "config.json"
+        config.write_text('{"unrelated": true}')
+
+        result = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "inspect",
+                "--dangerously-run-mcp-servers",
+                f"--suppress-mcpserver-io={suppress}",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "Snyk Agent Scan" in result.stdout
+        assert ("Tip: set --suppress-mcpserver-io=true" in result.stdout) is expect_tip
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_json_remains_machine_readable_with_verbose_logging(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "config.json"
+        config.write_text('{"mcp": []}')
+
+        result, output = inspect_json(
+            agent_scan_cmd,
+            "--verbose",
+            "--dangerously-run-mcp-servers",
+            str(config),
+        )
+
+        assert result.returncode == 0
+        assert output
+        assert "Verbose mode enabled" in result.stderr
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_inspect_accepts_shared_noop_flags_and_valid_oauth_file(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "config.json"
+        config.write_text('{"mcp": []}')
+        tokens = tmp_path / "tokens.json"
+        tokens.write_text("[]")
+
+        result, output = inspect_json(
+            agent_scan_cmd,
+            "--storage-file",
+            str(tmp_path / "unused-storage"),
+            "--analysis-url",
+            "https://unused.invalid/analysis",
+            "--verification-H",
+            "X-Unused: value",
+            "--mcp-oauth-tokens-path",
+            str(tokens),
+            "--skip-ssl-verify",
+            "--no-bootstrap",
+            "--scan-all-users",
+            "--server-timeout",
+            "1",
+            "--control-server",
+            "https://unused.invalid/control",
+            "--control-server-H",
+            "X-Control: value",
+            "--control-identifier",
+            "test-machine",
+            "--dangerously-run-mcp-servers",
+            str(config),
+        )
+
+        assert result.returncode == 0
+        assert only_result(output)["error"]["category"] == "unknown_config"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_missing_control_identifier_fails_before_inspection(self, agent_scan_cmd, tmp_path):
+        config = tmp_path / "config.json"
+        config.write_text('{"unrelated": true}')
+
+        result = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "inspect",
+                "--json",
+                "--control-server",
+                "https://unused.invalid/control",
+                "--dangerously-run-mcp-servers",
+                str(config),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert "missing a --control-identifier" in result.stdout
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_help_lists_inspect_specific_and_shared_flags(self, agent_scan_cmd):
+        result = subprocess.run(
+            [*agent_scan_cmd, "inspect", "--help"],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        for flag in (
+            "--json",
+            "--skills",
+            "--ci",
+            "--ignore-issues-codes",
+            "--server-timeout",
+            "--suppress-mcpserver-io",
+            "--dangerously-run-mcp-servers",
+        ):
+            assert flag in result.stdout
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    @pytest.mark.parametrize("oauth_content", [None, "not-json"], ids=["missing", "malformed"])
+    def test_invalid_oauth_token_file_fails(self, agent_scan_cmd, tmp_path, oauth_content):
+        config = tmp_path / "config.json"
+        config.write_text('{"unrelated": true}')
+        tokens = tmp_path / "tokens.json"
+        if oauth_content is not None:
+            tokens.write_text(oauth_content)
+
+        result, _ = inspect_json(
+            agent_scan_cmd,
+            "--mcp-oauth-tokens-path",
+            str(tokens),
+            "--dangerously-run-mcp-servers",
+            str(config),
+        )
+
+        assert result.returncode == 1

--- a/tests/unit/test_cli_control_server_no_consent.py
+++ b/tests/unit/test_cli_control_server_no_consent.py
@@ -82,7 +82,7 @@ class TestControlServerPushKeySkipsConsent:
                 "agent_scan.cli.discover_clients_to_inspect",
                 new=AsyncMock(return_value=(_fake_client_with_stdio(), [], [])),
             ),
-            patch("agent_scan.pipelines.inspect_pipeline", new=mock_inspect),
+            patch("agent_scan.pipelines.inspect_legacy_pipeline", new=mock_inspect),
             patch("agent_scan.pipelines.analyze_machine", new=mock_analyze),
         ):
             await run_scan(args, mode="scan")
@@ -113,7 +113,7 @@ class TestControlServerPushKeySkipsConsent:
                 new=AsyncMock(return_value=(_fake_client_with_stdio(), [], [])),
             ),
             patch(
-                "agent_scan.pipelines.inspect_pipeline",
+                "agent_scan.pipelines.inspect_legacy_pipeline",
                 new=AsyncMock(return_value=([path_result], [])),
             ),
             patch("agent_scan.pipelines.analyze_machine", new=AsyncMock(side_effect=lambda p, **kw: p)),

--- a/tests/unit/test_cli_interactivity.py
+++ b/tests/unit/test_cli_interactivity.py
@@ -935,7 +935,7 @@ class TestRunScanConsentAndStreamStderrWiring:
             ),
             patch("agent_scan.cli.collect_consent", return_value=declined),
             patch(
-                "agent_scan.cli.inspect_pipeline",
+                "agent_scan.cli.inspect_pipeline_inspected",
                 new_callable=AsyncMock,
                 return_value=([], []),
             ) as mock_inspect_pipeline,
@@ -1040,7 +1040,7 @@ class TestStdioHandshakeInvariants:
             ),
             patch("agent_scan.cli.collect_consent", return_value=declined) as mock_consent,
             patch(
-                "agent_scan.cli.inspect_pipeline",
+                "agent_scan.cli.inspect_pipeline_inspected",
                 new_callable=AsyncMock,
                 return_value=([], []),
             ) as mock_pipeline,

--- a/tests/unit/test_cli_interactivity.py
+++ b/tests/unit/test_cli_interactivity.py
@@ -935,7 +935,7 @@ class TestRunScanConsentAndStreamStderrWiring:
             ),
             patch("agent_scan.cli.collect_consent", return_value=declined),
             patch(
-                "agent_scan.cli.inspect_pipeline_inspected",
+                "agent_scan.cli.inspect_pipeline",
                 new_callable=AsyncMock,
                 return_value=([], []),
             ) as mock_inspect_pipeline,
@@ -1040,7 +1040,7 @@ class TestStdioHandshakeInvariants:
             ),
             patch("agent_scan.cli.collect_consent", return_value=declined) as mock_consent,
             patch(
-                "agent_scan.cli.inspect_pipeline_inspected",
+                "agent_scan.cli.inspect_pipeline",
                 new_callable=AsyncMock,
                 return_value=([], []),
             ) as mock_pipeline,

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -540,6 +540,69 @@ class TestCIMode:
             args = Namespace(json=True, print_errors=False, print_full_descriptions=False, verbose=False, ci=True)
             await print_scan_inspect(mode="scan", args=args)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("level", ["path", "server", "skill"])
+    async def test_inspect_ci_exits_1_on_operational_failure(self, level):
+        """Inspect preserves the old CI behavior for path/server failures and includes skills."""
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+        from agent_scan.models import InspectedPath, InspectedServer, InspectedSkill
+
+        error = ScanError(message="inspection failed", is_failure=True, category="skill_scan_error")
+        result = InspectedPath(
+            path="/test/path",
+            error=error if level == "path" else None,
+            servers=[InspectedServer(name="server", server=RemoteServer(url="http://localhost"), error=error)]
+            if level == "server"
+            else [],
+            skills=[InspectedSkill(name="skill", installation_path="/skill", error=error)] if level == "skill" else [],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes=None,
+                skills=True,
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                await print_scan_inspect(mode="inspect", args=args)
+            assert exc_info.value.code == 1
+
+    @pytest.mark.asyncio
+    async def test_inspect_ci_honors_ignored_operational_failure_code(self):
+        from argparse import Namespace
+
+        from agent_scan.cli import print_scan_inspect
+        from agent_scan.models import InspectedPath, InspectedSkill
+
+        result = InspectedPath(
+            path="/test/path",
+            skills=[
+                InspectedSkill(
+                    name="skill",
+                    installation_path="/skill",
+                    error=ScanError(message="failed", is_failure=True, category="skill_scan_error"),
+                )
+            ],
+        )
+
+        with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=[result]):
+            args = Namespace(
+                json=True,
+                print_errors=False,
+                print_full_descriptions=False,
+                verbose=False,
+                ci=True,
+                ignore_issues_codes="X002",
+                skills=True,
+            )
+            await print_scan_inspect(mode="inspect", args=args)
+
 
 class TestJSONOutput:
     """Test suite for JSON output functionality."""

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -29,7 +29,7 @@ from agent_scan.models import (
     SkillServer,
     StdioServer,
 )
-from agent_scan.pipelines import InspectArgs, inspect_pipeline
+from agent_scan.pipelines import InspectArgs, inspect_legacy_pipeline
 
 TEST_CANDIDATE_CLIENT = CandidateClient(
     name="test-client",
@@ -169,12 +169,12 @@ async def test_detected_usernames_falls_back_to_all_when_none_detected():
         shutil.rmtree(tmp)
 
 
-# --- inspect_pipeline username-reporting tests ---
+# --- inspect_legacy_pipeline username-reporting tests ---
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_reports_only_detected_usernames(home_dirs_with_agent):
-    """inspect_pipeline should only include usernames where an agent was actually found."""
+async def test_inspect_legacy_pipeline_reports_only_detected_usernames(home_dirs_with_agent):
+    """inspect_legacy_pipeline should only include usernames where an agent was actually found."""
     candidate, home_dirs = home_dirs_with_agent
 
     with (
@@ -187,15 +187,15 @@ async def test_inspect_pipeline_reports_only_detected_usernames(home_dirs_with_a
         mock_to_result.return_value = None
 
         args = InspectArgs(timeout=10, tokens=[], paths=[])
-        _, scanned_usernames = await inspect_pipeline(args)
+        _, scanned_usernames = await inspect_legacy_pipeline(args)
 
     assert sorted(scanned_usernames) == ["alice", "bob"]
     assert "charlie" not in scanned_usernames
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_falls_back_to_all_usernames_when_no_agents_detected():
-    """When no agents are detected and all_users is set, inspect_pipeline should report all usernames."""
+async def test_inspect_legacy_pipeline_falls_back_to_all_usernames_when_no_agents_detected():
+    """When no agents are detected and all_users is set, the legacy pipeline should report all usernames."""
     tmp = tempfile.mkdtemp()
     try:
         home_dirs = [
@@ -217,7 +217,7 @@ async def test_inspect_pipeline_falls_back_to_all_usernames_when_no_agents_detec
             patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
         ):
             args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=True)
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert sorted(scanned_usernames) == ["alice", "bob"]
     finally:
@@ -225,7 +225,7 @@ async def test_inspect_pipeline_falls_back_to_all_usernames_when_no_agents_detec
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_detected_usernames_are_sorted():
+async def test_inspect_legacy_pipeline_detected_usernames_are_sorted():
     """Detected usernames should be returned in sorted order for deterministic output."""
     tmp = tempfile.mkdtemp()
     try:
@@ -255,7 +255,7 @@ async def test_inspect_pipeline_detected_usernames_are_sorted():
             mock_to_result.return_value = None
 
             args = InspectArgs(timeout=10, tokens=[], paths=[])
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert scanned_usernames == ["alice", "bob", "charlie"]
     finally:
@@ -263,7 +263,7 @@ async def test_inspect_pipeline_detected_usernames_are_sorted():
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_single_user_detected_among_many():
+async def test_inspect_legacy_pipeline_single_user_detected_among_many():
     """When only one user out of many has an agent, only that username should be reported."""
     tmp = tempfile.mkdtemp()
     try:
@@ -294,7 +294,7 @@ async def test_inspect_pipeline_single_user_detected_among_many():
             mock_to_result.return_value = None
 
             args = InspectArgs(timeout=10, tokens=[], paths=[])
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert scanned_usernames == ["bob"]
     finally:
@@ -302,7 +302,7 @@ async def test_inspect_pipeline_single_user_detected_among_many():
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_deduplicates_usernames_across_clients():
+async def test_inspect_legacy_pipeline_deduplicates_usernames_across_clients():
     """When multiple clients detect the same user, the username should appear only once."""
     tmp = tempfile.mkdtemp()
     try:
@@ -340,7 +340,7 @@ async def test_inspect_pipeline_deduplicates_usernames_across_clients():
             mock_to_result.return_value = None
 
             args = InspectArgs(timeout=10, tokens=[], paths=[])
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert scanned_usernames == ["alice"]
     finally:
@@ -348,8 +348,8 @@ async def test_inspect_pipeline_deduplicates_usernames_across_clients():
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_no_clients_returns_empty_results():
-    """When no MCP clients are installed, inspect_pipeline should return empty scan_path_results."""
+async def test_inspect_legacy_pipeline_no_clients_returns_empty_results():
+    """When no MCP clients are installed, the legacy pipeline should return no scan path results."""
     tmp = tempfile.mkdtemp()
     try:
         home_dirs = [(Path(tmp) / "alice", "alice")]
@@ -367,7 +367,7 @@ async def test_inspect_pipeline_no_clients_returns_empty_results():
             patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
         ):
             args = InspectArgs(timeout=10, tokens=[], paths=[])
-            results, _ = await inspect_pipeline(args)
+            results, _ = await inspect_legacy_pipeline(args)
 
         assert results == []
     finally:
@@ -375,14 +375,14 @@ async def test_inspect_pipeline_no_clients_returns_empty_results():
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_missing_explicit_path_returns_file_not_found_error():
-    """When an explicit path doesn't exist, inspect_pipeline should return a file_not_found error result."""
+async def test_inspect_legacy_pipeline_missing_explicit_path_returns_file_not_found_error():
+    """An explicit missing path should produce a legacy file-not-found error result."""
     with (
         patch("agent_scan.pipelines.get_readable_home_directories", return_value=[]),
         patch("agent_scan.pipelines.client_to_inspect_from_path", new_callable=AsyncMock, return_value=[]),
     ):
         args = InspectArgs(timeout=10, tokens=[], paths=["/nonexistent/path.json"])
-        results, _ = await inspect_pipeline(args)
+        results, _ = await inspect_legacy_pipeline(args)
 
     assert len(results) == 1
     assert results[0].path == "/nonexistent/path.json"
@@ -391,7 +391,7 @@ async def test_inspect_pipeline_missing_explicit_path_returns_file_not_found_err
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_paths_mode_does_not_leak_all_usernames():
+async def test_inspect_legacy_pipeline_paths_mode_does_not_leak_all_usernames():
     """When using --paths, scanned_usernames should not fall back to all readable usernames."""
     tmp = tempfile.mkdtemp()
     try:
@@ -416,7 +416,7 @@ async def test_inspect_pipeline_paths_mode_does_not_leak_all_usernames():
             mock_to_result.return_value = None
 
             args = InspectArgs(timeout=10, tokens=[], paths=["/some/path/mcp.json"])
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert scanned_usernames == [getpass.getuser()]
     finally:
@@ -424,7 +424,7 @@ async def test_inspect_pipeline_paths_mode_does_not_leak_all_usernames():
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_discovery_mode_falls_back_to_all_usernames_when_no_agents_detected():
+async def test_inspect_legacy_pipeline_discovery_mode_falls_back_to_all_usernames_when_no_agents_detected():
     """Without --paths but with --scan-all-users, when no agents are detected, all readable usernames should be reported."""
     tmp = tempfile.mkdtemp()
     try:
@@ -447,7 +447,7 @@ async def test_inspect_pipeline_discovery_mode_falls_back_to_all_usernames_when_
             patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
         ):
             args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=True)
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert sorted(scanned_usernames) == ["alice", "bob"]
     finally:
@@ -601,7 +601,7 @@ async def test_glob_respects_max_depth():
 
 
 @pytest.mark.asyncio
-async def test_inspect_pipeline_discovery_mode_without_all_users_falls_back_to_current_user():
+async def test_inspect_legacy_pipeline_discovery_mode_without_all_users_falls_back_to_current_user():
     """Without --paths and without --scan-all-users, when no agents are detected, only the current user should be reported."""
     tmp = tempfile.mkdtemp()
     try:
@@ -624,7 +624,7 @@ async def test_inspect_pipeline_discovery_mode_without_all_users_falls_back_to_c
             patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
         ):
             args = InspectArgs(timeout=10, tokens=[], paths=[], all_users=False)
-            _, scanned_usernames = await inspect_pipeline(args)
+            _, scanned_usernames = await inspect_legacy_pipeline(args)
 
         assert scanned_usernames == [getpass.getuser()]
     finally:

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -5,13 +5,28 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from httpx import HTTPStatusError, Request, Response
 
-from agent_scan.inspect import get_mcp_config_per_client, inspect_client, inspected_client_to_scan_path_result
+from agent_scan.inspect import (
+    get_mcp_config_per_client,
+    inspect_client,
+    inspect_extension,
+    inspected_client_to_inspected_path,
+    inspected_client_to_scan_path_result,
+)
 from agent_scan.mcp_client import scan_mcp_config_file
 from agent_scan.models import (
     CandidateClient,
     ClientToInspect,
+    CouldNotParseMCPConfig,
+    InspectedClient,
+    InspectedExtensions,
+    InspectedServer,
+    InspectedSkill,
     RemoteServer,
+    ServerSignature,
+    ServerStartupError,
+    SkillServer,
     StdioServer,
 )
 from agent_scan.pipelines import InspectArgs, inspect_pipeline
@@ -22,6 +37,26 @@ TEST_CANDIDATE_CLIENT = CandidateClient(
     mcp_config_paths=["tests/mcp_servers/.test-client/mcp.json"],
     skills_dir_paths=["tests/mcp_servers/.test-client/skills"],
 )
+
+
+@pytest.mark.asyncio
+async def test_inspect_extension_preserves_direct_http_status_error_category():
+    request = Request("POST", "https://example.test/mcp")
+    status_error = HTTPStatusError(
+        "server error",
+        request=request,
+        response=Response(500, request=request),
+    )
+
+    with patch("agent_scan.inspect.check_server", new_callable=AsyncMock, side_effect=status_error):
+        result = await inspect_extension(
+            "remote",
+            RemoteServer(url="https://example.test/mcp", type="http"),
+            timeout=1,
+        )
+
+    assert result.signature_or_error is not None
+    assert result.signature_or_error.category == "server_http_error"
 
 
 @pytest.fixture
@@ -839,3 +874,154 @@ def test_config_path_survives_serialization_round_trip():
 
     restored = ScanPathResultsCreate.model_validate_json(payload.model_dump_json())
     assert restored.scan_path_results[0].servers[0].config_path == "/home/u/.mcp.json"
+
+
+# ---------------------------------------------------------------------------
+# inspected_client_to_inspected_path: the v2026-07-10 InspectedPath converter
+# used by the `inspect` command (scan keeps inspected_client_to_scan_path_result).
+# ---------------------------------------------------------------------------
+
+
+def test_inspected_client_to_inspected_path(tmp_path):
+    """Splits an InspectedClient into servers (carrying the signature) and
+    skills (carrying collected files), and joins
+    config-level parse errors onto the path."""
+    from mcp.types import Implementation, InitializeResult
+
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("---\nname: my-skill\n---\ndo things")
+    (skill_dir / "run.py").write_text("print('hi')")
+
+    signature = ServerSignature(
+        metadata=InitializeResult(
+            protocolVersion="2024-11-05",
+            capabilities={},
+            serverInfo=Implementation(name="sqlite", version="1"),
+        ),
+    )
+    client = InspectedClient(
+        name="cursor",
+        client_path="/proj",
+        extensions={
+            "/proj/.mcp.json": [
+                InspectedExtensions(
+                    name="sqlite",
+                    config=StdioServer(command="uvx", args=["sqlite-mcp"], type="stdio"),
+                    signature_or_error=signature,
+                ),
+            ],
+            "/proj/skills": [
+                InspectedExtensions(
+                    name="my-skill",
+                    config=SkillServer(path=str(skill_dir)),
+                    signature_or_error=None,
+                ),
+            ],
+            "/proj/bad.json": CouldNotParseMCPConfig(message="bad config", traceback="tb"),
+        },
+    )
+
+    result = inspected_client_to_inspected_path(client)
+
+    assert result.client == "cursor"
+    assert result.path == "/proj"
+
+    assert [s.name for s in result.servers] == ["sqlite"]
+    mcp = result.servers[0]
+    assert isinstance(mcp, InspectedServer)
+    assert mcp.config_path == "/proj/.mcp.json"
+    assert isinstance(mcp.server, StdioServer)
+    assert mcp.signature is signature
+    assert mcp.error is None
+
+    assert [s.name for s in result.skills] == ["my-skill"]
+    skill = result.skills[0]
+    assert isinstance(skill, InspectedSkill)
+    assert skill.installation_path == str(skill_dir)
+    assert {f.path for f in skill.files} == {"SKILL.md", "run.py"}
+    assert skill.error is None
+
+    # config-level parse error is joined onto the path
+    assert result.error is not None and "bad config" in (result.error.message or "")
+
+
+def test_inspected_client_to_inspected_path_carries_server_error():
+    """A failed MCP handshake becomes the InspectedServer.error (no signature)."""
+    client = InspectedClient(
+        name="cursor",
+        client_path="/proj",
+        extensions={
+            "/proj/.mcp.json": [
+                InspectedExtensions(
+                    name="broken",
+                    config=StdioServer(command="nope", type="stdio"),
+                    signature_or_error=ServerStartupError(message="boom", traceback="tb"),
+                ),
+            ],
+        },
+    )
+
+    result = inspected_client_to_inspected_path(client)
+
+    assert len(result.servers) == 1
+    server = result.servers[0]
+    assert server.signature is None
+    assert server.error is not None
+    assert server.error.message == "boom"
+    assert server.error.category == "server_startup"
+
+
+def test_inspected_client_to_inspected_path_carries_skill_file_collection_error(tmp_path):
+    skill_path = tmp_path / "missing-skill"
+    client = InspectedClient(
+        name="cursor",
+        client_path="/proj",
+        extensions={
+            "/proj/skills": [
+                InspectedExtensions(
+                    name="missing-skill",
+                    config=SkillServer(path=str(skill_path)),
+                    signature_or_error=None,
+                ),
+            ],
+        },
+    )
+
+    result = inspected_client_to_inspected_path(client)
+
+    assert len(result.skills) == 1
+    skill = result.skills[0]
+    assert skill.files == []
+    assert skill.error is not None
+    assert skill.error.category == "skill_scan_error"
+    assert "collect skill files" in (skill.error.message or "")
+    assert str(skill_path) not in (skill.error.message or "")
+
+
+def test_inspected_client_to_inspected_path_recovers_from_unexpected_collection_error(tmp_path):
+    skill_path = tmp_path / "skill"
+    skill_path.mkdir()
+    client = InspectedClient(
+        name="cursor",
+        client_path="/proj",
+        extensions={
+            "/proj/skills": [
+                InspectedExtensions(
+                    name="skill",
+                    config=SkillServer(path=str(skill_path)),
+                    signature_or_error=None,
+                ),
+            ],
+        },
+    )
+
+    with patch("agent_scan.inspect.collect_skill_files", side_effect=RuntimeError("unexpected")):
+        result = inspected_client_to_inspected_path(client)
+
+    assert result.skills[0].files == []
+    assert result.skills[0].error is not None
+    assert result.skills[0].error.category == "skill_scan_error"
+    assert result.skills[0].error.exception == "unexpected"
+    assert result.skills[0].error.traceback is not None
+    assert "RuntimeError: unexpected" in result.skills[0].error.traceback

--- a/tests/unit/test_printer.py
+++ b/tests/unit/test_printer.py
@@ -1,6 +1,9 @@
-from mcp.types import Prompt, Tool
+import types
 
-from agent_scan.printer import format_entity_line, format_servers_line
+from mcp.types import Implementation, InitializeResult, Prompt, Tool
+
+from agent_scan.models import InspectedPath, InspectedServer, InspectedSkill, ServerSignature, SkillFile, StdioServer
+from agent_scan.printer import format_entity_line, format_servers_line, format_skill_file_line, print_inspected_machine
 
 
 class TestFormatServersLine:
@@ -79,3 +82,53 @@ class TestFormatEntityLine:
         result = format_entity_line(entity, issues=[], is_skill=True, full_description=True).plain
         assert "instruction SKILL.md" in result
         assert "instructionSKILL.md" not in result
+
+
+class TestPrintInspectedMachine:
+    """The `inspect` command's InspectedPath renderer: MCP servers with their
+    entities, and skills with their files."""
+
+    def test_renders_servers_and_skills(self, capsys):
+        signature = ServerSignature(
+            metadata=InitializeResult(
+                protocolVersion="2024-11-05",
+                capabilities={},
+                serverInfo=Implementation(name="github", version="1"),
+            ),
+            tools=[Tool(name="create_pull_request", description="d", inputSchema={})],
+        )
+        path = InspectedPath(
+            client="cursor",
+            path="/proj",
+            servers=[
+                InspectedServer(
+                    name="github",
+                    server=StdioServer(command="uvx", args=["gh"], type="stdio"),
+                    signature=signature,
+                )
+            ],
+            skills=[
+                InspectedSkill(
+                    name="my-skill",
+                    installation_path="/proj/.skills/my-skill",
+                    files=[SkillFile(path="SKILL.md", content="x"), SkillFile(path="run.py", content="y")],
+                )
+            ],
+        )
+
+        print_inspected_machine([path], args=types.SimpleNamespace(skills=True))
+        out = capsys.readouterr().out
+
+        assert "found 1 mcp server and 1 skill" in out
+        assert "github" in out
+        assert "create_pull_request" in out  # server entity from the signature
+        assert "my-skill" in out
+        assert "SKILL.md" in out and "run.py" in out  # skill files
+
+    def test_skill_file_name_is_rendered_as_plain_text(self):
+        line = format_skill_file_line(SkillFile(path="[bold]not-markup[/bold].md", content="x"))
+        assert "[bold]not-markup[/bold].md" in line.plain
+
+    def test_empty_machine(self, capsys):
+        print_inspected_machine([], args=types.SimpleNamespace(skills=True))
+        assert "No MCP client configurations found" in capsys.readouterr().out

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -365,3 +365,25 @@ def test_collect_skill_files_rejects_path_that_is_not_file_or_directory(tmp_path
 
     with pytest.raises(ValueError, match="not a file or directory"):
         collect_skill_files(str(special_path))
+
+
+def test_collect_skill_files_rejects_symlinked_skill_path(tmp_path):
+    target = tmp_path / "target.md"
+    target.write_text("secret")
+    link = tmp_path / "skill.md"
+    link.symlink_to(target)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        collect_skill_files(str(link))
+
+
+def test_collect_skill_files_rejects_symlinked_file_inside_skill(tmp_path):
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret")
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("instructions")
+    (skill / "outside.txt").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symbolic link"):
+        collect_skill_files(str(skill))


### PR DESCRIPTION
What

Migrates the inspect command to the v2026-07-10 inventory model. inspect now produces an InspectedPath with separate servers and skills collections instead of the old mixed ScanPathResult, and renders each as its own group. inspect --json gains separate servers/skills keys and drops the always-empty issues/labels.

Scope

- New InspectedClient -> InspectedPath converter, wiring the already-shipped collect_skill_files into each skill's files.
- Inspect command + printer + --json render the servers/skills inventory.
- scan is completely untouched (still legacy ScanPathResult). No backend call, no API-version change.