### PR TITLE
feat: add ignore-failure-codes and ignore-risks

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -23,7 +23,9 @@ from agent_scan.models import (
     FAILURE_CATEGORY_TO_CODE,
     ControlServer,
     InspectedPath,
+    McpServerRiskIndexes,
     ScanResponse,
+    SkillRiskIndexes,
     TokenAndClientInfo,
     TokenAndClientInfoList,
 )
@@ -43,6 +45,8 @@ from agent_scan.version import version_info
 logging.getLogger().setLevel(logging.CRITICAL + 1)  # Higher than any standard level
 # Add null handler to prevent "No handler found" warnings
 logging.getLogger().addHandler(logging.NullHandler())
+
+CLI_USAGE_ERROR_EXIT_CODE = 2
 
 
 class MissingIdentifierError(Exception):
@@ -312,7 +316,16 @@ def add_scan_arguments(scan_parser):
     add_control_server_arguments(scan_parser)
 
 
-def setup_scan_parser(scan_parser, add_files=True):
+def add_ignore_failure_codes_argument(parser) -> None:
+    parser.add_argument(
+        "--ignore-failure-codes",
+        type=str,
+        default=None,
+        help="Comma-separated X-codes to omit from --ci exit evaluation",
+    )
+
+
+def setup_scan_parser(scan_parser, add_files=True, add_ci_ignore_options=True):
     if add_files:
         scan_parser.add_argument(
             "files",
@@ -322,6 +335,14 @@ def setup_scan_parser(scan_parser, add_files=True):
             metavar="CONFIG_FILE",
         )
     add_common_arguments(scan_parser)
+    if add_ci_ignore_options:
+        scan_parser.add_argument(
+            "--ignore-risks",
+            type=str,
+            default=None,
+            help="Comma-separated risk names to omit from --ci output and exit evaluation",
+        )
+        add_ignore_failure_codes_argument(scan_parser)
     add_server_arguments(scan_parser)
     add_scan_arguments(scan_parser)
 
@@ -424,7 +445,7 @@ def enforce_consent_requirements(args) -> None:
             "scans, so CI runs must confirm trust explicitly.",
             file=sys.stderr,
         )
-        sys.exit(2)
+        sys.exit(CLI_USAGE_ERROR_EXIT_CODE)
 
 
 def main():
@@ -478,6 +499,7 @@ def main():
         description="Inspect and display MCP tools, prompts, and resources without security verification.",
     )
     add_common_arguments(inspect_parser)
+    add_ignore_failure_codes_argument(inspect_parser)
     add_server_arguments(inspect_parser)
     add_control_server_arguments(inspect_parser)
     inspect_parser.add_argument(
@@ -500,7 +522,7 @@ def main():
     evo_parser = subparsers.add_parser("evo", help="Push scan results to Snyk Evo")
 
     # use the same parser as scan
-    setup_scan_parser(evo_parser)
+    setup_scan_parser(evo_parser, add_ci_ignore_options=False)
 
     # GUARD command
     guard_parser = subparsers.add_parser(
@@ -795,6 +817,57 @@ def _collect_failure_codes(result: list[InspectedPath]) -> set[str]:
     return codes
 
 
+_VALID_RISK_NAMES = frozenset(McpServerRiskIndexes.model_fields) | frozenset(SkillRiskIndexes.model_fields)
+_VALID_FAILURE_CODES = frozenset(FAILURE_CATEGORY_TO_CODE.values())
+
+
+def _parse_comma_separated(raw_value: str | None) -> set[str]:
+    """Parse a comma-separated CLI option into non-empty, stripped values."""
+    return {value.strip() for value in raw_value.split(",") if value.strip()} if raw_value else set()
+
+
+def _parse_ignore_risks(args, ci_mode: bool) -> set[str]:
+    """Parse --ignore-risks, which is valid only for CI scans."""
+    requested = _parse_comma_separated(getattr(args, "ignore_risks", None))
+    if requested and not ci_mode:
+        rich.print(
+            "[bold red]Error: --ignore-risks can only be used with --ci.[/bold red]",
+            file=sys.stderr,
+        )
+        sys.exit(CLI_USAGE_ERROR_EXIT_CODE)
+
+    unknown = requested - _VALID_RISK_NAMES
+    for name in sorted(unknown):
+        rich.print(f"[yellow]Warning: unknown risk name: {name}[/yellow]", file=sys.stderr)
+    return requested - unknown
+
+
+def _parse_ignore_failure_codes(args, ci_mode: bool) -> set[str]:
+    """Parse --ignore-failure-codes, which is valid only for CI scans."""
+    requested = _parse_comma_separated(getattr(args, "ignore_failure_codes", None))
+    if requested and not ci_mode:
+        rich.print(
+            "[bold red]Error: --ignore-failure-codes can only be used with --ci.[/bold red]",
+            file=sys.stderr,
+        )
+        sys.exit(CLI_USAGE_ERROR_EXIT_CODE)
+
+    unknown = requested - _VALID_FAILURE_CODES
+    for code in sorted(unknown):
+        rich.print(f"[yellow]Warning: unknown failure code: {code}[/yellow]", file=sys.stderr)
+    return requested - unknown
+
+
+def _apply_ignore_risks(response: ScanResponse, ignored_risks: set[str]) -> None:
+    """Remove ignored risks before rendering and CI exit evaluation."""
+    for path in response.scan_path_responses:
+        risk_indexes = [server.risk_indexes for server in path.server_risks]
+        risk_indexes.extend(skill.risk_indexes for skill in path.skill_risks)
+        for indexes in risk_indexes:
+            for name in ignored_risks & indexes.__class__.model_fields.keys():
+                setattr(indexes, name, None)
+
+
 def _has_risks(response: ScanResponse) -> bool:
     for path in response.scan_path_responses:
         for server in path.server_risks:
@@ -818,7 +891,11 @@ def _collect_response_failure_codes(response: ScanResponse) -> set[str]:
     return codes
 
 
-def _handle_ci_exit(result: list[InspectedPath] | ScanResponse, json_output: bool) -> None:
+def _handle_ci_exit(
+    result: list[InspectedPath] | ScanResponse,
+    json_output: bool,
+    ignored_failure_codes: set[str] | None = None,
+) -> None:
     """In CI mode, exit with code 1 if any risk or runtime failure remains."""
     if isinstance(result, ScanResponse):
         failure_codes = _collect_response_failure_codes(result)
@@ -826,6 +903,7 @@ def _handle_ci_exit(result: list[InspectedPath] | ScanResponse, json_output: boo
     else:
         failure_codes = _collect_failure_codes(result)
         has_risks = False
+    failure_codes -= ignored_failure_codes or set()
     if not has_risks and not failure_codes:
         return
 
@@ -847,6 +925,8 @@ async def print_scan_inspect(mode="scan", args=None):
     print_errors: bool = hasattr(args, "print_errors") and args.print_errors
     full_description: bool = hasattr(args, "print_full_descriptions") and args.print_full_descriptions
     ci_mode: bool = hasattr(args, "ci") and args.ci
+    ignored_risks = _parse_ignore_risks(args, ci_mode)
+    ignored_failure_codes = _parse_ignore_failure_codes(args, ci_mode)
 
     if json_output:
         with suppress_stdout():
@@ -861,10 +941,12 @@ async def print_scan_inspect(mode="scan", args=None):
         else:
             print_inspected_machine(inspected_paths, print_errors, full_description, args)
         if ci_mode:
-            _handle_ci_exit(inspected_paths, json_output)
+            _handle_ci_exit(inspected_paths, json_output, ignored_failure_codes)
         return
 
     response = cast("ScanResponse", result)
+    if ignored_risks:
+        _apply_ignore_risks(response, ignored_risks)
 
     if json_output:
         print(json.dumps(response.model_dump(mode="json", exclude_none=True), indent=2))
@@ -872,7 +954,7 @@ async def print_scan_inspect(mode="scan", args=None):
         print_scan_response(response, print_errors, args)
 
     if ci_mode:
-        _handle_ci_exit(response, json_output)
+        _handle_ci_exit(response, json_output, ignored_failure_codes)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/test_scan.py
+++ b/tests/e2e/test_scan.py
@@ -12,6 +12,7 @@ from pytest_lazy_fixtures import lf
 
 class _V20260710AnalysisHandler(BaseHTTPRequestHandler):
     requests: ClassVar[list[dict]] = []
+    server_error: ClassVar[dict | None] = None
 
     def do_POST(self):
         body = self.rfile.read(int(self.headers["Content-Length"]))
@@ -30,6 +31,7 @@ class _V20260710AnalysisHandler(BaseHTTPRequestHandler):
                             "affected_tools": [0],
                         }
                     },
+                    **({"error": type(self).server_error} if type(self).server_error else {}),
                 }
                 for server in path["servers"]
             ]
@@ -70,6 +72,7 @@ class _V20260710AnalysisHandler(BaseHTTPRequestHandler):
 @pytest.fixture
 def v20260710_analysis_server():
     _V20260710AnalysisHandler.requests = []
+    _V20260710AnalysisHandler.server_error = None
     server = HTTPServer(("127.0.0.1", 0), _V20260710AnalysisHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -112,6 +115,80 @@ class TestFullScanFlow:
         assert [server["name"] for server in path_request["servers"]] == ["Math"]
         assert path_request["skills"] == []
         assert "server" in path_request["servers"][0]
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    @pytest.mark.parametrize(
+        ("ignored_risk", "expected_exit"),
+        [("private_data", 0), ("dangerous_words", 1)],
+    )
+    def test_ignore_risks_filters_output_and_ci_exit(
+        self,
+        agent_scan_cmd,
+        v20260710_analysis_server,
+        ignored_risk,
+        expected_exit,
+    ):
+        result = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "scan",
+                "--json",
+                "--ci",
+                "--ignore-risks",
+                ignored_risk,
+                "--dangerously-run-mcp-servers",
+                "tests/mcp_servers/configs_files/math_config.json",
+                "--analysis-url",
+                v20260710_analysis_server,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == expected_exit, result.stderr
+        output = json.loads(result.stdout)
+        risk_indexes = output["scan_path_responses"][0]["server_risks"][0]["risk_indexes"]
+        if ignored_risk == "private_data":
+            assert "private_data" not in risk_indexes
+        else:
+            assert risk_indexes["private_data"]["score"] == 750
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_ignore_failure_codes_suppresses_ci_exit_but_preserves_error(
+        self,
+        agent_scan_cmd,
+        v20260710_analysis_server,
+    ):
+        _V20260710AnalysisHandler.server_error = {
+            "message": "could not start server",
+            "category": "server_startup",
+            "is_failure": True,
+        }
+        result = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "scan",
+                "--json",
+                "--ci",
+                "--ignore-risks",
+                "private_data",
+                "--ignore-failure-codes",
+                "X001",
+                "--dangerously-run-mcp-servers",
+                "tests/mcp_servers/configs_files/math_config.json",
+                "--analysis-url",
+                v20260710_analysis_server,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        output = json.loads(result.stdout)
+        server = output["scan_path_responses"][0]["server_risks"][0]
+        assert "private_data" not in server["risk_indexes"]
+        assert server["error"]["category"] == "server_startup"
+        assert server["error"]["message"] == "could not start server"
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     def test_v20260710_skill_scan_sends_files_and_prints_plain_risk(self, agent_scan_cmd, v20260710_analysis_server):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from agent_scan.cli import _handle_ci_exit, print_scan_inspect, setup_scan_parser
-from agent_scan.models import ScanError
+from agent_scan.models import InspectedPath, ScanError
 from agent_scan.models.api.v20260710 import (
     McpServerRiskIndexes,
     McpServerRiskResponse,
@@ -19,13 +19,21 @@ from agent_scan.models.api.v20260710 import (
 )
 
 
-def _cli_args(*, json_output: bool, ci: bool) -> Namespace:
+def _cli_args(
+    *,
+    json_output: bool,
+    ci: bool,
+    ignore_risks: str | None = None,
+    ignore_failure_codes: str | None = None,
+) -> Namespace:
     return Namespace(
         json=json_output,
         print_errors=False,
         print_full_descriptions=False,
         verbose=False,
         ci=ci,
+        ignore_risks=ignore_risks,
+        ignore_failure_codes=ignore_failure_codes,
         skills=True,
     )
 
@@ -37,6 +45,24 @@ def test_scan_parser_defaults_to_v20260710_and_rejects_removed_issue_flag():
     assert parser.parse_args([]).analysis_url.endswith("?version=2026-07-10")
     with pytest.raises(SystemExit, match="2"):
         parser.parse_args(["--ignore-issues-codes", "W001"])
+
+
+def test_scan_parser_accepts_ignore_risks():
+    parser = argparse.ArgumentParser()
+    setup_scan_parser(parser)
+
+    args = parser.parse_args(["--ignore-risks", "private_data,malicious_code"])
+
+    assert args.ignore_risks == "private_data,malicious_code"
+
+
+def test_scan_parser_accepts_ignore_failure_codes():
+    parser = argparse.ArgumentParser()
+    setup_scan_parser(parser)
+
+    args = parser.parse_args(["--ignore-failure-codes", "X001,X007"])
+
+    assert args.ignore_failure_codes == "X001,X007"
 
 
 @pytest.mark.asyncio
@@ -134,6 +160,240 @@ async def test_scan_ci_exits_for_analysis_response_failure():
     with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
         with pytest.raises(SystemExit, match="1"):
             await print_scan_inspect(mode="scan", args=_cli_args(json_output=True, ci=True))
+
+
+@pytest.mark.asyncio
+async def test_ignore_risks_requires_ci(capsys):
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock) as run_scan:
+        with pytest.raises(SystemExit, match="2"):
+            await print_scan_inspect(
+                mode="scan",
+                args=_cli_args(json_output=False, ci=False, ignore_risks="private_data"),
+            )
+
+    assert "--ignore-risks can only be used with --ci" in capsys.readouterr().err
+    run_scan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignore_failure_codes_requires_ci(capsys):
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock) as run_scan:
+        with pytest.raises(SystemExit, match="2"):
+            await print_scan_inspect(
+                mode="scan",
+                args=_cli_args(json_output=False, ci=False, ignore_failure_codes="X001"),
+            )
+
+    assert "--ignore-failure-codes can only be used with --ci" in capsys.readouterr().err
+    run_scan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignored_risk_is_removed_from_json_and_ci_exit(capsys):
+    response = ScanResponse(
+        scan_path_responses=[
+            ScanPathResponse(
+                path="/config",
+                server_risks=[
+                    McpServerRiskResponse(
+                        name="server",
+                        risk_indexes=McpServerRiskIndexes(
+                            private_data=RiskScore(score=300, evidence="reads private data")
+                        ),
+                    )
+                ],
+                skill_risks=[
+                    SkillRiskResponse(
+                        name="skill",
+                        risk_indexes=SkillRiskIndexes(malicious_code=SkillRiskScore(score=600, evidence="runs code")),
+                    )
+                ],
+            )
+        ]
+    )
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        await print_scan_inspect(
+            mode="scan",
+            args=_cli_args(json_output=True, ci=True, ignore_risks="private_data,malicious_code"),
+        )
+
+    output = json.loads(capsys.readouterr().out)
+    path = output["scan_path_responses"][0]
+    assert "private_data" not in path["server_risks"][0]["risk_indexes"]
+    assert "malicious_code" not in path["skill_risks"][0]["risk_indexes"]
+
+
+@pytest.mark.asyncio
+async def test_non_ignored_risk_still_prints_and_fails_ci(capsys):
+    response = ScanResponse(
+        scan_path_responses=[
+            ScanPathResponse(
+                path="/config",
+                server_risks=[
+                    McpServerRiskResponse(
+                        name="server",
+                        risk_indexes=McpServerRiskIndexes(
+                            dangerous_words=RiskScore(score=100, evidence="dangerous word"),
+                            private_data=RiskScore(score=300, evidence="reads private data"),
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        with pytest.raises(SystemExit, match="1"):
+            await print_scan_inspect(
+                mode="scan",
+                args=_cli_args(json_output=False, ci=True, ignore_risks="private_data"),
+            )
+
+    captured = capsys.readouterr()
+    assert "Private data" not in captured.out
+    assert "Dangerous words" in captured.out
+    assert "risks found" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_ignored_risk_does_not_suppress_runtime_failure(capsys):
+    response = ScanResponse(
+        scan_path_responses=[
+            ScanPathResponse(
+                path="/config",
+                server_risks=[
+                    McpServerRiskResponse(
+                        name="server",
+                        error=ScanError(message="could not start server", category="server_startup", is_failure=True),
+                        risk_indexes=McpServerRiskIndexes(
+                            private_data=RiskScore(score=300, evidence="reads private data")
+                        ),
+                    )
+                ],
+            )
+        ]
+    )
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        with pytest.raises(SystemExit, match="1"):
+            await print_scan_inspect(
+                mode="scan",
+                args=_cli_args(json_output=False, ci=True, ignore_risks="private_data"),
+            )
+
+    captured = capsys.readouterr()
+    assert "Private data" not in captured.out
+    assert "runtime failure codes: X001" in captured.err
+    assert "risks found" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_ignored_failure_code_remains_visible_but_does_not_fail_scan_ci(capsys):
+    response = ScanResponse(
+        scan_path_responses=[
+            ScanPathResponse(
+                path="/config",
+                server_risks=[
+                    McpServerRiskResponse(
+                        name="server",
+                        error=ScanError(message="could not start server", category="server_startup", is_failure=True),
+                    )
+                ],
+            )
+        ]
+    )
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        await print_scan_inspect(
+            mode="scan",
+            args=_cli_args(json_output=False, ci=True, ignore_failure_codes="X001"),
+        )
+
+    captured = capsys.readouterr()
+    assert "[X001 info]" in captured.out
+    assert "could not start server" in captured.out
+    assert "exiting with code 1" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_ignored_failure_code_applies_to_inspect_ci(capsys):
+    inspected_paths = [
+        InspectedPath(
+            path="/config",
+            error=ScanError(message="could not parse config", category="parse_error", is_failure=True),
+        )
+    ]
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=inspected_paths):
+        await print_scan_inspect(
+            mode="inspect",
+            args=_cli_args(json_output=False, ci=True, ignore_failure_codes="X005"),
+        )
+
+    captured = capsys.readouterr()
+    assert "X005" in captured.out
+    assert "could not parse config" in captured.out
+    assert "exiting with code 1" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_unknown_ignore_risk_warns_and_is_tolerated(capsys):
+    response = ScanResponse(scan_path_responses=[ScanPathResponse(path="/config")])
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        await print_scan_inspect(
+            mode="scan",
+            args=_cli_args(json_output=False, ci=True, ignore_risks="future_risk"),
+        )
+
+    assert "unknown risk name: future_risk" in capsys.readouterr().err
+
+
+@pytest.mark.asyncio
+async def test_ignore_failure_codes_warns_for_unknown_codes(capsys):
+    response = ScanResponse(
+        scan_path_responses=[
+            ScanPathResponse(
+                path="/config",
+                error=ScanError(message="could not start server", category="server_startup", is_failure=True),
+            )
+        ]
+    )
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        await print_scan_inspect(
+            mode="scan",
+            args=_cli_args(json_output=False, ci=True, ignore_failure_codes="X001,X999"),
+        )
+
+    captured = capsys.readouterr()
+    assert "could not start server" in captured.out
+    assert "unknown failure code: X999" in captured.err
+    assert "exiting with code 1" not in captured.err
+
+
+@pytest.mark.asyncio
+async def test_ignore_failure_codes_is_case_sensitive(capsys):
+    response = ScanResponse(
+        scan_path_responses=[
+            ScanPathResponse(
+                path="/config",
+                error=ScanError(message="could not start server", category="server_startup", is_failure=True),
+            )
+        ]
+    )
+
+    with patch("agent_scan.cli.run_scan", new_callable=AsyncMock, return_value=response):
+        with pytest.raises(SystemExit, match="1"):
+            await print_scan_inspect(
+                mode="scan",
+                args=_cli_args(json_output=False, ci=True, ignore_failure_codes="x001"),
+            )
+
+    captured = capsys.readouterr()
+    assert "unknown failure code: x001" in captured.err
+    assert "runtime failure codes: X001" in captured.err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
What

Adds two CI-only flags that let you tune what makes scan (and inspect) fail:

- \--ignore-risks - comma-separated risk names (e.g. dangerous_words,private_data) to accept and hide.
- \--ignore-failure-codes - comma-separated runtime failure codes (e.g. X001,X007) to tolerate.

Why

The v2026 cutover (PR 5) dropped the old --ignore-issues-codes and left --ci firing on any risk or failure with no way to suppress known/accepted ones. This restores that control, split cleanly into the two things you might want to ignore: security risks vs. operational failures.

Behavior

- \--ignore-risks takes risk names. The risk is removed from human and JSON output and no longer fails --ci.
- \--ignore-failure-codes takes X-codes. Only the --ci exit decision changes; the error stays visible in output.

The distinction is deliberate: an ignored risk is one you've consciously accepted and don't want to see, while an ignored failure is diagnostic info you still want reported - it just shouldn't break the build.

Both flags:

- Require --ci (using them without it exits 2, before any scanning runs).
- Are additive filters - non-ignored risks/failures still fail CI as before.

\--ignore-risks is scan-only (inspect has no risk analysis); --ignore-failure-codes works on both scan and inspect; unknown risk names warn and are tolerated.