### PR TITLE
fix(cli): reject orphaned control-server headers

### DIFF
--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -594,13 +594,14 @@ def main():
 
     args = parser.parse_args()
 
+    argv_to_check = sys.argv[: sys.argv.index("--")] if "--" in sys.argv else sys.argv
     header_flag = "--control-server-H"
-    for header_index, arg in enumerate(sys.argv):
+    for header_index, arg in enumerate(argv_to_check):
         if arg != header_flag:
             continue
         has_preceding_server = any(
-            server_index + 1 < header_index and not sys.argv[server_index + 1].startswith("--")
-            for server_index, server_arg in enumerate(sys.argv[:header_index])
+            server_index + 1 < header_index and not argv_to_check[server_index + 1].startswith("--")
+            for server_index, server_arg in enumerate(argv_to_check[:header_index])
             if server_arg == "--control-server"
         )
         if not has_preceding_server:

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -594,6 +594,18 @@ def main():
 
     args = parser.parse_args()
 
+    header_flag = "--control-server-H"
+    for header_index, arg in enumerate(sys.argv):
+        if arg != header_flag:
+            continue
+        has_preceding_server = any(
+            server_index + 1 < header_index and not sys.argv[server_index + 1].startswith("--")
+            for server_index, server_arg in enumerate(sys.argv[:header_index])
+            if server_arg == "--control-server"
+        )
+        if not has_preceding_server:
+            parser.error("--control-server-H requires --control-server")
+
     # Attach parsed control servers to args
     args.control_servers = control_servers
 

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -183,6 +183,75 @@ class TestControlServerParsing:
 class TestCLIArgumentParsing:
     """Test suite for overall CLI argument parsing with control servers."""
 
+    @pytest.mark.parametrize("token", [None, "test-token"], ids=["without_token", "with_token"])
+    def test_orphaned_control_server_header_is_rejected_before_authentication(self, monkeypatch, capsys, token):
+        from agent_scan.cli import main
+
+        if token is None:
+            monkeypatch.delenv("SNYK_TOKEN", raising=False)
+        else:
+            monkeypatch.setenv("SNYK_TOKEN", token)
+        monkeypatch.setattr(sys, "argv", ["snyk-agent-scan", "scan", "--control-server-H", "x-client-id: key"])
+
+        with patch("agent_scan.cli.print_scan_inspect", new_callable=AsyncMock) as mock_scan:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+        assert "--control-server-H requires --control-server" in capsys.readouterr().err
+        mock_scan.assert_not_awaited()
+
+    def test_control_server_header_before_later_server_is_rejected(self, monkeypatch, capsys):
+        from agent_scan.cli import main
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "snyk-agent-scan",
+                "scan",
+                "--control-server-H",
+                "x-client-id: key",
+                "--control-server",
+                "https://server.example",
+                "--control-identifier",
+                "test-machine",
+            ],
+        )
+
+        with patch("agent_scan.cli.print_scan_inspect", new_callable=AsyncMock) as mock_scan:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 2
+        assert "--control-server-H requires --control-server" in capsys.readouterr().err
+        mock_scan.assert_not_awaited()
+
+    def test_valid_control_server_header_block_still_dispatches(self, monkeypatch):
+        from agent_scan.cli import main
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "snyk-agent-scan",
+                "scan",
+                "--control-server",
+                "https://server.example",
+                "--control-server-H",
+                "x-client-id: key",
+                "--control-identifier",
+                "test-machine",
+            ],
+        )
+
+        with patch("agent_scan.cli.print_scan_inspect", new_callable=AsyncMock) as mock_scan:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        mock_scan.assert_awaited_once()
+
     def test_scan_with_multiple_control_servers_parses_correctly(self):
         """Test that multiple control servers are parsed correctly."""
         test_argv = [

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -227,6 +227,18 @@ class TestCLIArgumentParsing:
         assert "--control-server-H requires --control-server" in capsys.readouterr().err
         mock_scan.assert_not_awaited()
 
+    def test_positional_control_server_header_after_separator_is_not_rejected(self, monkeypatch):
+        from agent_scan.cli import main
+
+        monkeypatch.setattr(sys, "argv", ["snyk-agent-scan", "scan", "--", "--control-server-H"])
+
+        with patch("agent_scan.cli.print_scan_inspect", new_callable=AsyncMock) as mock_scan:
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        mock_scan.assert_awaited_once()
+
     def test_valid_control_server_header_block_still_dispatches(self, monkeypatch):
         from agent_scan.cli import main
 


### PR DESCRIPTION
Reject unscoped `--control-server-H` options before authentication so users receive a flag-specific error instead of a misleading token prompt. Adds coverage for token states, ordering, and valid blocks.