### PR TITLE
fix: fix api version issue when analysis url passes old version

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -88,7 +88,7 @@ With `--no-skills`, explicit skill paths, skill directories, and automatically d
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--storage-file FILE` | string | `~/.mcp-scan` | Path for local scan state and cached results. |
-| `--analysis-url URL` | string | version-specific | Analysis API endpoint; see the defaults below. With `SNYK_TOKEN`, the CLI rewrites it to the `/cli/analysis-machine` variant automatically. |
+| `--analysis-url URL` | string | version-specific | Analysis API endpoint; see the defaults below. With `SNYK_TOKEN`, the CLI rewrites it to the `/cli/analysis-machine` variant automatically. In v0.6+, any supplied `version` query parameter is replaced with `2026-07-10` so the URL cannot select an incompatible wire contract. |
 | `--verification-H HEADER` | repeatable | — | Extra HTTP header for the analysis request, in `Name: value` format. Repeat for multiple headers. |
 | `--skip-ssl-verify` | boolean | `false` | Disable TLS certificate verification for analysis and upload calls. |
 | `--mcp-oauth-tokens-path PATH` | string | — | JSON file containing MCP OAuth tokens (`TokenAndClientInfoList` schema) for OAuth-protected remote MCP servers. |

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -170,7 +170,7 @@ def add_common_arguments(parser):
         "--analysis-url",
         type=str,
         default="https://api.snyk.io/hidden/mcp-scan/analysis-machine?version=2026-07-10",
-        help="URL endpoint for the verification server",
+        help="URL endpoint for the verification server; Agent Scan always uses the 2026-07-10 API version",
         metavar="URL",
     )
     parser.add_argument(

--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -6,6 +6,7 @@ import os
 import ssl
 import traceback
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import aiohttp
 import certifi
@@ -67,6 +68,20 @@ class SnykTokenError(Exception):
 _SYNC_ANALYSIS_PATH = "/hidden/mcp-scan/analysis-machine"
 _ASYNC_ANALYSIS_PATH = "/hidden/agent-scan/async/analysis"
 _AGENT_SCAN_CONFIG_PATH = "/hidden/agent-scan/config"
+_ANALYSIS_API_VERSION = "2026-07-10"
+
+
+def _force_analysis_api_version(analysis_url: str) -> str:
+    """Use the API version implemented by this Agent Scan release.
+
+    ``--analysis-url`` selects the server, not the wire contract. Allowing its
+    query string to select a legacy version can pair the v2026 request model
+    with a v2025 response, which the client cannot deserialize.
+    """
+    parsed = urlsplit(analysis_url)
+    query = [(name, value) for name, value in parse_qsl(parsed.query, keep_blank_values=True) if name != "version"]
+    query.append(("version", _ANALYSIS_API_VERSION))
+    return urlunsplit(parsed._replace(query=urlencode(query)))
 
 
 async def _async_analysis_enabled(
@@ -366,6 +381,7 @@ async def analyze_machine(
         skip_ssl_verify: Whether to skip SSL verification
         scan_context: Optional dict containing scan metadata to include in the request
     """
+    analysis_url = _force_analysis_api_version(analysis_url)
     logger.debug(f"Analyzing scan path with URL: {analysis_url}")
 
     # for analysis server we never push personal information

--- a/tests/e2e/test_scan.py
+++ b/tests/e2e/test_scan.py
@@ -5,6 +5,7 @@ import subprocess
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import ClassVar
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from pytest_lazy_fixtures import lf
@@ -12,14 +13,41 @@ from pytest_lazy_fixtures import lf
 
 class _V20260710AnalysisHandler(BaseHTTPRequestHandler):
     requests: ClassVar[list[dict]] = []
+    request_paths: ClassVar[list[str]] = []
+    request_headers: ClassVar[list[dict[str, str]]] = []
+    config_request_paths: ClassVar[list[str]] = []
+    config_request_headers: ClassVar[list[dict[str, str]]] = []
     server_error: ClassVar[dict | None] = None
     server_entities: ClassVar[list[dict]] = []
     skill_files: ClassVar[list[dict]] = []
+
+    def do_GET(self):
+        type(self).config_request_paths.append(self.path)
+        type(self).config_request_headers.append(dict(self.headers))
+        response = json.dumps({"async_analysis_enabled": False}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
 
     def do_POST(self):
         body = self.rfile.read(int(self.headers["Content-Length"]))
         request = json.loads(body)
         type(self).requests.append(request)
+        type(self).request_paths.append(self.path)
+        type(self).request_headers.append(dict(self.headers))
+
+        requested_version = parse_qs(urlsplit(self.path).query).get("version")
+        if requested_version != ["2026-07-10"]:
+            response = json.dumps({"scan_path_results": []}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+            return
+
         path_responses = []
         for path in request["scan_path_requests"]:
             server_risks = [
@@ -74,6 +102,10 @@ class _V20260710AnalysisHandler(BaseHTTPRequestHandler):
 @pytest.fixture
 def v20260710_analysis_server():
     _V20260710AnalysisHandler.requests = []
+    _V20260710AnalysisHandler.request_paths = []
+    _V20260710AnalysisHandler.request_headers = []
+    _V20260710AnalysisHandler.config_request_paths = []
+    _V20260710AnalysisHandler.config_request_headers = []
     _V20260710AnalysisHandler.server_error = None
     _V20260710AnalysisHandler.server_entities = []
     _V20260710AnalysisHandler.skill_files = []
@@ -119,6 +151,45 @@ class TestFullScanFlow:
         assert [server["name"] for server in path_request["servers"]] == ["Math"]
         assert path_request["skills"] == []
         assert "server" in path_request["servers"][0]
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_ads_style_push_key_scan_forces_v20260710_when_analysis_url_requests_legacy_version(
+        self, agent_scan_cmd, v20260710_analysis_server
+    ):
+        legacy_analysis_url = v20260710_analysis_server.replace("version=2026-07-10", "version=2025-09-02")
+        control_server_url = legacy_analysis_url.replace(
+            "/hidden/mcp-scan/analysis-machine", "/hidden/mcp-scan/push"
+        ).replace("version=2025-09-02", "version=2025-08-28")
+        result = subprocess.run(
+            [
+                *agent_scan_cmd,
+                "scan",
+                "--json",
+                "--dangerously-run-mcp-servers",
+                "tests/mcp_servers/configs_files/math_config.json",
+                "--analysis-url",
+                legacy_analysis_url,
+                "--control-server",
+                control_server_url,
+                "--control-server-H",
+                "x-client-id: 8cd00172-0825-43a8-8990-16bdb15de7d6",
+                "--control-identifier",
+                "ads-installer-test-host",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+        output = json.loads(result.stdout)
+        assert "scan_path_responses" in output
+        assert parse_qs(urlsplit(_V20260710AnalysisHandler.config_request_paths[0]).query)["version"] == ["2026-07-10"]
+        assert parse_qs(urlsplit(_V20260710AnalysisHandler.request_paths[0]).query)["version"] == ["2026-07-10"]
+        assert _V20260710AnalysisHandler.config_request_headers[0]["X-Push-Key"] == (
+            "8cd00172-0825-43a8-8990-16bdb15de7d6"
+        )
+        assert _V20260710AnalysisHandler.request_headers[0]["X-Push-Key"] == ("8cd00172-0825-43a8-8990-16bdb15de7d6")
+        assert _V20260710AnalysisHandler.request_headers[0]["X-Push"] == "skip"
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     def test_scan_compacts_components_unless_show_full_discovery_is_set(

--- a/tests/unit/test_verify_api.py
+++ b/tests/unit/test_verify_api.py
@@ -653,7 +653,13 @@ class TestAnalyzeMachineAuthPrecedence:
         mock_session.__aexit__ = AsyncMock(return_value=None)
         return mock_session
 
-    async def _run(self, *, push_key: str | None, env: dict[str, str]):
+    async def _run(
+        self,
+        *,
+        push_key: str | None,
+        env: dict[str, str],
+        analysis_url: str | None = None,
+    ):
         inspected_paths = [InspectedPath(path="/test/path")]
         with (
             patch("agent_scan.verify_api.aiohttp.ClientSession") as mock_session_class,
@@ -664,7 +670,7 @@ class TestAnalyzeMachineAuthPrecedence:
             mock_session_class.return_value = self._make_mock_session()
             await analyze_machine(
                 inspected_paths=inspected_paths,
-                analysis_url=self._ANALYSIS_URL,
+                analysis_url=analysis_url or self._ANALYSIS_URL,
                 identifier=None,
                 push_key=push_key,
             )
@@ -673,6 +679,17 @@ class TestAnalyzeMachineAuthPrecedence:
             posted_url = call_args[0][0]
             posted_headers = call_args[1]["headers"]
         return posted_url, posted_headers
+
+    @pytest.mark.asyncio
+    async def test_push_key_forces_v20260710_when_analysis_url_requests_legacy_version(self):
+        os.environ.pop("SNYK_TOKEN", None)
+        posted_url, _ = await self._run(
+            push_key="push-abc",
+            env={},
+            analysis_url=("https://api.snyk.io/hidden/mcp-scan/analysis-machine?region=us&version=2025-09-02"),
+        )
+
+        assert posted_url == ("https://api.snyk.io/hidden/mcp-scan/analysis-machine?region=us&version=2026-07-10")
 
     @pytest.mark.asyncio
     async def test_push_key_only_uses_x_push_key_header_on_unrewritten_url(self):


### PR DESCRIPTION
v0.6.0 only works with analysis API 20260710, but it could happen that the --analysis-url flag passes in an old version which will break the analysis.