### PR TITLE
feat: add --push-key and --machine-id flags

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -107,10 +107,10 @@ The URL version must match the request and response models used by the installed
 
 | v0.6 flag | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--push-key KEY` | string | — | Push key used to authenticate with the analysis server. Replaces the deprecated `--control-server-H "x-client-id: <push-key>"` pattern below and does not require a `--control-server` block. |
-| `--machine-id ID` | string | — | Non-anonymous identifier for this machine (for example, email, hostname, or serial number). Replaces the deprecated `--control-identifier` below. |
+| `--push-key KEY` | string | — | Push key used to authenticate with the analysis server. Replaces the soon-to-be-deprecated `--control-server-H "x-client-id: <push-key>"` pattern below and does not require a `--control-server` block. |
+| `--machine-id ID` | string | — | Non-anonymous identifier for this machine (for example, email, hostname, or serial number). Replaces the soon-to-be-deprecated `--control-identifier` below. |
 
-If both a new flag and its deprecated equivalent are given, the new flag wins. Using `--control-server-H` for the `x-client-id` trick, or `--control-identifier` on a single `--control-server` block, emits a one-time deprecation warning pointing at `--push-key` / `--machine-id`.
+If both a new flag and its soon-to-be-deprecated equivalent are given, the new flag wins. Using `--control-server-H` for the `x-client-id` trick, or `--control-identifier` on a single `--control-server` block, emits a one-time deprecation warning pointing at `--push-key` / `--machine-id`.
 
 ### Control server (enterprise upload, on deprecation path)
 
@@ -145,7 +145,7 @@ The bootstrap implementation was removed in v0.5.14. In v0.5.14 and later—incl
 
 #### Push keys and stdio MCP servers (`scan` only)
 
-Enterprise uploads include a push key, either via `--push-key` (v0.6 and later) or the deprecated `x-client-id` header in `--control-server-H`. Agent Scan treats this as an unattended run, so there is no terminal consent prompt.
+Enterprise uploads include a push key, either via `--push-key` (v0.6 and later) or the soon-to-be-deprecated `x-client-id` header in `--control-server-H`. Agent Scan treats this as an unattended run, so there is no terminal consent prompt.
 
 | `--dangerously-run-mcp-servers` | Consent prompts | Stdio MCP subprocesses |
 | --- | --- | --- |
@@ -316,7 +316,7 @@ snyk-agent-scan scan --config-file agent-scan.yaml \
 ```
 
 > Notes:
-> - `push_key` / `machine_id` are ordinary scalars in the precedence cascade (`code defaults < config file < explicit CLI flags`), but they resolve *against the deprecated `--control-server-H` / `--control-identifier` flags* rather than against each other's own CLI flag. Concretely: if you pass the legacy `--control-server-H "x-client-id: ..."` / `--control-identifier` on the command line but the config file sets `push_key` / `machine_id`, the **file's value wins**, because only an *explicit* `--push-key` / `--machine-id` on the command line — not the legacy flags — is checked as an override. Passing `--push-key` / `--machine-id` explicitly on the command line still overrides the file as usual.
+> - `push_key` / `machine_id` are ordinary scalars in the precedence cascade (`code defaults < config file < explicit CLI flags`), but they resolve *against the soon-to-be-deprecated `--control-server-H` / `--control-identifier` flags* rather than against each other's own CLI flag. Concretely: if you pass the legacy `--control-server-H "x-client-id: ..."` / `--control-identifier` on the command line but the config file sets `push_key` / `machine_id`, the **file's value wins**, because only an *explicit* `--push-key` / `--machine-id` on the command line — not the legacy flags — is checked as an override. Passing `--push-key` / `--machine-id` explicitly on the command line still overrides the file as usual.
 > - `skills` is on by default. In YAML, set `skills: false` to disable skill scanning (equivalent to `--no-skills`); there is no separate `no_skills` toggle — the `skills` key is the single source of truth.
 > - `dangerously_run_mcp_servers: true` in the file has the same effect as the flag, including satisfying the `--ci` requirement that it be set — a config file can therefore enable stdio MCP server execution. This is intended, but review config files with that in mind.
 > - **On/off flags set to `true` in a file cannot be turned off on the command line.** Flags such as `json`, `scan_all_users`, and `dangerously_run_mcp_servers` are `store_true` and have no `--no-…` counterpart, so once a config file sets them to `true` there is no CLI flag to override them back to `false` for a single run — edit or omit the file instead. (`skills` is the exception: it has `--no-skills`.)
@@ -386,7 +386,7 @@ snyk-agent-scan guard uninstall {claude,cursor,codex,all} [OPTIONS]
 
 | Variable | Used by | Description |
 | --- | --- | --- |
-| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan` unless a push key is configured through `--push-key` (v0.6 and later) or the deprecated `--control-server-H`. Never required for `evo`, which always mints and uses its own push key. Obtain it from https://app.snyk.io/account. |
+| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan` unless a push key is configured through `--push-key` (v0.6 and later) or the soon-to-be-deprecated `--control-server-H`. Never required for `evo`, which always mints and uses its own push key. Obtain it from https://app.snyk.io/account. |
 | `SNYK_CLI_USE` | Binary invoked through Snyk CLI | Set to `true` by the extension so analysis uses the proxy-authenticated `/cli/analysis-machine` endpoint. |
 | `SNYK_API` | Standalone CLI | Override the Snyk API base URL for local development or custom regions. |
 | `SNYK_TENANT_ID` | Snyk CLI extension | Alternative to `--tenant-id` for the Go wrapper. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -290,6 +290,12 @@ verification_H:
 files:
   - ~/.cursor/mcp.json
   - ~/.claude/skills
+
+# Push key and machine identifier (v0.6 and later)
+push_key: <push-key>
+machine_id: user@example.com
+
+# Legacy control-server block (superseded by push_key/machine_id above)
 control_servers:
   - url: https://api.snyk.io/hidden/mcp-scan/push?version=2025-08-28
     identifier: user@example.com
@@ -310,6 +316,7 @@ snyk-agent-scan scan --config-file agent-scan.yaml \
 ```
 
 > Notes:
+> - `push_key` / `machine_id` are ordinary scalars in the precedence cascade (`code defaults < config file < explicit CLI flags`), but they resolve *against the deprecated `--control-server-H` / `--control-identifier` flags* rather than against each other's own CLI flag. Concretely: if you pass the legacy `--control-server-H "x-client-id: ..."` / `--control-identifier` on the command line but the config file sets `push_key` / `machine_id`, the **file's value wins**, because only an *explicit* `--push-key` / `--machine-id` on the command line — not the legacy flags — is checked as an override. Passing `--push-key` / `--machine-id` explicitly on the command line still overrides the file as usual.
 > - `skills` is on by default. In YAML, set `skills: false` to disable skill scanning (equivalent to `--no-skills`); there is no separate `no_skills` toggle — the `skills` key is the single source of truth.
 > - `dangerously_run_mcp_servers: true` in the file has the same effect as the flag, including satisfying the `--ci` requirement that it be set — a config file can therefore enable stdio MCP server execution. This is intended, but review config files with that in mind.
 > - **On/off flags set to `true` in a file cannot be turned off on the command line.** Flags such as `json`, `scan_all_users`, and `dangerously_run_mcp_servers` are `store_true` and have no `--no-…` counterpart, so once a config file sets them to `true` there is no CLI flag to override them back to `false` for a single run — edit or omit the file instead. (`skills` is the exception: it has `--no-skills`.)
@@ -379,7 +386,7 @@ snyk-agent-scan guard uninstall {claude,cursor,codex,all} [OPTIONS]
 
 | Variable | Used by | Description |
 | --- | --- | --- |
-| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan`/`evo` unless a push key is configured through `--push-key` (v0.6 and later) or the deprecated `--control-server-H`. Obtain it from https://app.snyk.io/account. |
+| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan` unless a push key is configured through `--push-key` (v0.6 and later) or the deprecated `--control-server-H`. Never required for `evo`, which always mints and uses its own push key. Obtain it from https://app.snyk.io/account. |
 | `SNYK_CLI_USE` | Binary invoked through Snyk CLI | Set to `true` by the extension so analysis uses the proxy-authenticated `/cli/analysis-machine` endpoint. |
 | `SNYK_API` | Standalone CLI | Override the Snyk API base URL for local development or custom regions. |
 | `SNYK_TENANT_ID` | Snyk CLI extension | Alternative to `--tenant-id` for the Go wrapper. |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,6 +103,15 @@ The default analysis URL is the main version-dependent value:
 
 The URL version must match the request and response models used by the installed Agent Scan version.
 
+### Push key and machine identifier (v0.6 and later)
+
+| v0.6 flag | Type | Default | Description |
+| --- | --- | --- | --- |
+| `--push-key KEY` | string | — | Push key used to authenticate with the analysis server. Replaces the deprecated `--control-server-H "x-client-id: <push-key>"` pattern below and does not require a `--control-server` block. |
+| `--machine-id ID` | string | — | Non-anonymous identifier for this machine (for example, email, hostname, or serial number). Replaces the deprecated `--control-identifier` below. |
+
+If both a new flag and its deprecated equivalent are given, the new flag wins. Using `--control-server-H` for the `x-client-id` trick, or `--control-identifier` on a single `--control-server` block, emits a one-time deprecation warning pointing at `--push-key` / `--machine-id`.
+
 ### Control server (enterprise upload, on deprecation path)
 
 Upload analyzed results to one or more control servers, typically Snyk Evo. This upload mechanism is on a deprecation path and will be replaced.
@@ -136,7 +145,7 @@ The bootstrap implementation was removed in v0.5.14. In v0.5.14 and later—incl
 
 #### Push keys and stdio MCP servers (`scan` only)
 
-Enterprise uploads include an `x-client-id` push key in `--control-server-H`. Agent Scan treats this as an unattended run, so there is no terminal consent prompt.
+Enterprise uploads include a push key, either via `--push-key` (v0.6 and later) or the deprecated `x-client-id` header in `--control-server-H`. Agent Scan treats this as an unattended run, so there is no terminal consent prompt.
 
 | `--dangerously-run-mcp-servers` | Consent prompts | Stdio MCP subprocesses |
 | --- | --- | --- |
@@ -260,6 +269,8 @@ The analysis result is the main version difference:
 3. Run `scan` with the Snyk push endpoint configured automatically.
 4. Revoke the push key when finished.
 
+`evo` always authenticates with the push key it mints for that run. In v0.6 and later, an explicit `--push-key` on the command line is ignored — it never substitutes for the minted key.
+
 `--ci` is accepted for compatibility but does not change `evo` output or exit status. Shared argument validation still requires it to be paired with `--dangerously-run-mcp-servers`. Use `scan` when CI risk/failure evaluation is required.
 
 ## `guard`
@@ -308,7 +319,7 @@ snyk-agent-scan guard uninstall {claude,cursor,codex,all} [OPTIONS]
 
 | Variable | Used by | Description |
 | --- | --- | --- |
-| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan`/`evo` unless a push key is configured through `--control-server-H`. Obtain it from https://app.snyk.io/account. |
+| `SNYK_TOKEN` | Standalone CLI | Snyk API token for analysis (`Authorization: token …`). Required for `scan`/`evo` unless a push key is configured through `--push-key` (v0.6 and later) or the deprecated `--control-server-H`. Obtain it from https://app.snyk.io/account. |
 | `SNYK_CLI_USE` | Binary invoked through Snyk CLI | Set to `true` by the extension so analysis uses the proxy-authenticated `/cli/analysis-machine` endpoint. |
 | `SNYK_API` | Standalone CLI | Override the Snyk API base URL for local development or custom regions. |
 | `SNYK_TENANT_ID` | Snyk CLI extension | Alternative to `--tenant-id` for the Go wrapper. |

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -157,6 +157,38 @@ def parse_control_servers(argv) -> list[ControlServer]:
     return control_servers
 
 
+def _warn_deprecated_flag(flag_name: str, replacement: str) -> None:
+    rich.print(
+        f"[yellow]Warning: {flag_name} is deprecated and will be removed in a future release. "
+        f"Use {replacement} instead.[/yellow]",
+        file=sys.stderr,
+    )
+
+
+def warn_deprecated_control_flags(args) -> None:
+    """Warn once per invocation for each deprecated control-server flag used.
+
+    --control-server-H is a generic "additional header" flag, so it only
+    warns when it's actually carrying the x-client-id push-key trick, not
+    when it's used for an unrelated custom header. --control-identifier
+    warns on any use, even though --machine-id can only hold a single value
+    and can't represent the distinct identifiers a multi-control-server
+    setup requires — the warning still nudges toward the replacement for
+    the common single-server case.
+    """
+    raw_headers = getattr(args, "control_server_H", None)
+    if raw_headers:
+        try:
+            headers = parse_headers(raw_headers)
+        except ValueError:
+            headers = {}
+        if any("x-client-id" in header.lower() for header in headers):
+            _warn_deprecated_flag("--control-server-H", "--push-key")
+
+    if getattr(args, "control_identifier", None):
+        _warn_deprecated_flag("--control-identifier", "--machine-id")
+
+
 def add_common_arguments(parser):
     """Add arguments that are common to multiple commands."""
     parser.add_argument(
@@ -309,6 +341,20 @@ def add_control_server_arguments(parser):
             "Non-anonymous identifier for that control server (for example: email, hostname, serial number)."
         ),
     )
+    parser.add_argument(
+        "--push-key",
+        type=str,
+        default=None,
+        help="Push key used to authenticate with the analysis server.",
+        metavar="KEY",
+    )
+    parser.add_argument(
+        "--machine-id",
+        type=str,
+        default=None,
+        help="Non-anonymous identifier for this machine (for example: hostname, serial number). ",
+        metavar="ID",
+    )
 
 
 def add_scan_arguments(scan_parser):
@@ -360,6 +406,34 @@ def setup_scan_parser(scan_parser, add_files=True, add_ci_ignore_options=True, a
     add_scan_arguments(scan_parser)
 
 
+def _effective_push_key(args) -> str | None:
+    """Push key from --push-key, falling back to the deprecated --control-server-H
+    x-client-id header.
+
+    On evo, an externally-supplied --push-key is ignored: evo always
+    authenticates with the one-time key it mints and injects into
+    args.control_servers, so an outside value must never silently replace
+    it (both before minting, where it would wrongly suppress the upfront
+    tenant/token prompts, and after, where it would wrongly override the
+    minted key).
+    """
+    if getattr(args, "command", None) != "evo":
+        push_key = getattr(args, "push_key", None)
+        if push_key is not None:
+            return push_key
+    return get_push_key(getattr(args, "control_servers", []) or [])
+
+
+def _effective_identifier(args) -> str | None:
+    """Machine identifier from --machine-id, falling back to the deprecated
+    --control-identifier on the first control-server block."""
+    machine_id = getattr(args, "machine_id", None)
+    if machine_id is not None:
+        return machine_id
+    control_servers = getattr(args, "control_servers", None) or []
+    return next((s.identifier for s in control_servers), None)
+
+
 def is_interactive_run(args) -> bool:
     """
     True when the run is a manual, interactive invocation by a human who can
@@ -369,7 +443,7 @@ def is_interactive_run(args) -> bool:
     if command == "inspect":
         return True
     # If the scan is run with a push key, skip consent prompts.
-    has_push_key = bool(get_push_key(getattr(args, "control_servers", []) or []))
+    has_push_key = bool(_effective_push_key(args))
     return not has_push_key
 
 
@@ -410,7 +484,7 @@ def decide_handshake(args) -> HandshakeDecision:
     # inspect always qualifies.
     # scan / no-subcommand qualifies when there is no push key.
     is_attended_scan = command == "inspect" or (
-        (command is None or command == "scan") and not bool(get_push_key(getattr(args, "control_servers", []) or []))
+        (command is None or command == "scan") and not bool(_effective_push_key(args))
     )
     if is_attended_scan:
         return HandshakeDecision(do_stdio_handshake=True, collect_consent=True)
@@ -627,6 +701,8 @@ def main():
     # Attach parsed control servers to args
     args.control_servers = control_servers
 
+    warn_deprecated_control_flags(args)
+
     # Resolve deferred defaults and enforce safety rules before dispatching.
     resolve_server_io_default(args)
     enforce_consent_requirements(args)
@@ -673,6 +749,12 @@ async def evo(args):
     3. Revokes the client_id
     """
     from agent_scan.pushkeys import mint_push_key, revoke_push_key
+
+    if getattr(args, "push_key", None) is not None:
+        rich.print(
+            "[yellow]Note: evo always authenticates with a key it mints itself; "
+            "the --push-key you supplied will be ignored.[/yellow]"
+        )
 
     rich.print(
         "Go to https://app.snyk.io and select the tenant on the left nav bar. "
@@ -781,8 +863,12 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> ScanRespo
         skip_ssl_verify: bool = bool(hasattr(args, "skip_ssl_verify") and args.skip_ssl_verify)
 
         control_servers: list[ControlServer] = args.control_servers if hasattr(args, "control_servers") else []
-        # For the analysis backend, pick the first identifier from control_servers
-        identifier: str | None = next((s.identifier for s in control_servers), None)
+        # --machine-id / --push-key take precedence over the deprecated
+        # --control-identifier / --control-server-H equivalents. Resolved once
+        # here so every downstream consumer (PushArgs, the pipeline) sees the
+        # same already-resolved value instead of re-deriving it.
+        identifier: str | None = _effective_identifier(args)
+        push_key: str | None = _effective_push_key(args)
 
         analyze_args = AnalyzeArgs(
             analysis_url=args.analysis_url,
@@ -794,6 +880,7 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> ScanRespo
         )
         push_args = PushArgs(
             control_servers=control_servers,
+            push_key=push_key,
             skip_ssl_verify=skip_ssl_verify,
             version=version_info,
         )

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -1045,7 +1045,8 @@ async def evo(args):
     if getattr(args, "push_key", None) is not None:
         rich.print(
             "[yellow]Note: evo always authenticates with a key it mints itself; "
-            "the --push-key you supplied will be ignored.[/yellow]"
+            "the --push-key you supplied will be ignored.[/yellow]",
+            file=sys.stderr,
         )
         args.push_key = None
 

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -426,7 +426,7 @@ def apply_config_file(parser: argparse.ArgumentParser, args: argparse.Namespace,
 
     # control_servers is assembled outside argparse (see parse_control_servers),
     # so it is handled here with complete-replacement semantics.
-    if "control_servers" in config and not any(dest in explicit for dest in _CONTROL_SERVER_DESTS):
+    if config.get("control_servers") is not None and not any(dest in explicit for dest in _CONTROL_SERVER_DESTS):
         args.control_servers = control_servers_from_config(config["control_servers"])
 
     # For every remaining key the rule is uniform: an explicit CLI flag wins,
@@ -451,6 +451,13 @@ def apply_config_file(parser: argparse.ArgumentParser, args: argparse.Namespace,
             continue
         if key in explicit:
             continue  # explicit CLI flag wins over the config file (whole value)
+        if value is None:
+            # A key written with no value (``push_key:``) parses as YAML/Python
+            # ``None``. Treat that the same as the key being absent entirely
+            # (keep the code default / CLI-derived value) rather than running
+            # it through the type converter, which would otherwise stringify
+            # it into the literal text "None".
+            continue
         # Validate/convert exactly as argparse would for the equivalent CLI flag
         # (type converters, choices, scalar-vs-list shape) before assigning.
         setattr(args, key, _coerce_config_value(dest_to_action[key], raw_key, value))

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -331,17 +331,22 @@ def _convert_config_scalar(action: argparse.Action, raw_key: str, value: object)
     Apply the action's ``type`` converter to a single YAML scalar and enforce
     ``choices`` — the same validation argparse would run on a CLI token.
 
-    ``type`` converters (e.g. ``str2bool``, ``int``, ``float``) accept a string,
-    so we only invoke them when the YAML value is a string; a value already
-    parsed by YAML into the target native type (``server_timeout: 30``) is kept
-    as-is. Exits with code 2 on a failed conversion or an out-of-choices value.
+    ``type`` converters (e.g. ``str2bool``, ``int``, ``float``, ``str``) always
+    receive a string on the CLI (argv tokens are strings), so we stringify a
+    non-string YAML value (e.g. ``push_key: 12345``, ``server_timeout: 30``)
+    before converting, rather than only converting when YAML already handed us
+    a string. This is a generic, type-agnostic rule that applies to every
+    scalar flag: it normalizes a numeric YAML value into the flag's real type
+    (``str`` for a string flag, ``float`` for ``server_timeout``, etc.)
+    instead of silently keeping the mismatched native YAML type. Exits with
+    code 2 on a failed conversion or an out-of-choices value.
     """
     converted = value
     # argparse's ``type`` may be a registered type name (str) rather than a
     # callable; guard with callable() so we only invoke real converters.
-    if callable(action.type) and isinstance(value, str):
+    if callable(action.type):
         try:
-            converted = action.type(value)
+            converted = action.type(value) if isinstance(value, str) else action.type(str(value))
         except (ValueError, TypeError) as exc:
             _fail_config(f"Invalid config file: '{raw_key}' has an invalid value {value!r} ({exc}).")
     if action.choices is not None and converted not in action.choices:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -22,7 +22,7 @@ from agent_scan.models import (
     TokenAndClientInfo,
 )
 from agent_scan.redact import redact_inspected_path
-from agent_scan.utils import get_push_key, get_readable_home_directories
+from agent_scan.utils import get_readable_home_directories
 from agent_scan.verify_api import analyze_machine
 from agent_scan.well_known_clients import get_well_known_clients
 
@@ -48,6 +48,10 @@ class AnalyzeArgs(BaseModel):
 
 class PushArgs(BaseModel):
     control_servers: list[ControlServer]
+    # Already resolved by the caller (e.g. cli.py's _effective_push_key,
+    # which also enforces evo's mint-your-own-key rule). This pipeline does
+    # not derive it from control_servers headers itself.
+    push_key: str | None = None
     skip_ssl_verify: bool = False
     version: str | None = None
 
@@ -208,8 +212,8 @@ async def inspect_analyze_push_pipeline(
         identifier=analyze_args.identifier,
         additional_headers=analyze_args.additional_headers,
         verbose=verbose,
-        skip_pushing=bool(push_args.control_servers),
-        push_key=get_push_key(push_args.control_servers),
+        skip_pushing=bool(push_args.control_servers) or bool(push_args.push_key),
+        push_key=push_args.push_key,
         max_retries=analyze_args.max_retries,
         skip_ssl_verify=analyze_args.skip_ssl_verify,
         scan_context=scan_context,

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -212,7 +212,7 @@ async def inspect_analyze_push_pipeline(
         identifier=analyze_args.identifier,
         additional_headers=analyze_args.additional_headers,
         verbose=verbose,
-        skip_pushing=bool(push_args.control_servers) or (push_args.push_key is not None),
+        skip_pushing=bool(push_args.control_servers) or bool(push_args.push_key),
         push_key=push_args.push_key,
         max_retries=analyze_args.max_retries,
         skip_ssl_verify=analyze_args.skip_ssl_verify,

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -212,7 +212,7 @@ async def inspect_analyze_push_pipeline(
         identifier=analyze_args.identifier,
         additional_headers=analyze_args.additional_headers,
         verbose=verbose,
-        skip_pushing=bool(push_args.control_servers) or bool(push_args.push_key),
+        skip_pushing=bool(push_args.control_servers) or (push_args.push_key is not None),
         push_key=push_args.push_key,
         max_retries=analyze_args.max_retries,
         skip_ssl_verify=analyze_args.skip_ssl_verify,

--- a/tests/unit/test_cli_config_file.py
+++ b/tests/unit/test_cli_config_file.py
@@ -7,6 +7,8 @@ import pytest
 
 from agent_scan.cli import (
     _coerce_config_value,
+    _effective_identifier,
+    _effective_push_key,
     apply_config_file,
     control_servers_from_config,
     explicitly_provided_dests,
@@ -466,3 +468,91 @@ class TestApplyConfigFilePushKeyAndMachineId:
         parser, args = _parse(argv)
         apply_config_file(parser, args, argv)
         assert args.push_key == ""
+
+
+class TestConfigFilePushKeyPrecedenceOverLegacyFlags:
+    """Unlike most flags, --push-key / --machine-id resolve against the
+    *deprecated* --control-server-H / --control-identifier flags, not
+    against their own CLI spelling (see cli._effective_push_key /
+    _effective_identifier). This means the usual "CLI beats config file"
+    rule does not hold across that old/new pair: a config-file push_key /
+    machine_id wins even when the legacy flags are passed explicitly on the
+    command line, because only an *explicit* --push-key / --machine-id (not
+    the legacy flags) counts as an override.
+    """
+
+    def test_config_push_key_wins_over_legacy_cli_flags(self, tmp_path):
+        path = _write_yaml(tmp_path, "push_key: config-push-key\n")
+        argv = [
+            "scan",
+            "--config-file",
+            path,
+            "--control-server",
+            "https://cli-server.com",
+            "--control-server-H",
+            "x-client-id: legacy-cli-key",
+            "--control-identifier",
+            "cli-user",
+        ]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key == "config-push-key"
+        assert _effective_push_key(args) == "config-push-key"
+
+    def test_config_machine_id_wins_over_legacy_cli_flag(self, tmp_path):
+        path = _write_yaml(tmp_path, "machine_id: config-machine-id\n")
+        argv = [
+            "scan",
+            "--config-file",
+            path,
+            "--control-server",
+            "https://cli-server.com",
+            "--control-identifier",
+            "cli-user",
+        ]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.machine_id == "config-machine-id"
+        assert _effective_identifier(args) == "config-machine-id"
+
+    def test_explicit_cli_push_key_still_wins_over_legacy_flags_and_config(self, tmp_path):
+        # An *explicit* --push-key on the CLI is the one thing that legitimately
+        # overrides both the config file and the legacy flags.
+        path = _write_yaml(tmp_path, "push_key: config-push-key\n")
+        argv = [
+            "scan",
+            "--config-file",
+            path,
+            "--control-server",
+            "https://cli-server.com",
+            "--control-server-H",
+            "x-client-id: legacy-cli-key",
+            "--control-identifier",
+            "cli-user",
+            "--push-key",
+            "explicit-cli-push-key",
+        ]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key == "explicit-cli-push-key"
+        assert _effective_push_key(args) == "explicit-cli-push-key"
+
+    def test_no_config_push_key_still_falls_back_to_legacy_cli_header(self, tmp_path):
+        # Sanity check: without a config-file push_key, legacy CLI flags
+        # still work as before.
+        path = _write_yaml(tmp_path, "server_timeout: 30\n")
+        argv = [
+            "scan",
+            "--config-file",
+            path,
+            "--control-server",
+            "https://cli-server.com",
+            "--control-server-H",
+            "x-client-id: legacy-cli-key",
+            "--control-identifier",
+            "cli-user",
+        ]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key is None
+        assert _effective_push_key(args) == " legacy-cli-key"

--- a/tests/unit/test_cli_config_file.py
+++ b/tests/unit/test_cli_config_file.py
@@ -229,6 +229,17 @@ class TestApplyConfigFileScalars:
         assert args.server_timeout == 15
         assert "not_a_real_flag" in capsys.readouterr().err
 
+    def test_null_yaml_value_keeps_code_default_not_stringified(self, tmp_path):
+        # A key with no value (``analysis_url:``) parses as YAML null. It must
+        # be treated like the key was omitted (code default kept), not run
+        # through str() into the literal string "None".
+        path = _write_yaml(tmp_path, "analysis_url:\nserver_timeout: 15\n")
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.analysis_url == "https://api.snyk.io/hidden/mcp-scan/analysis-machine?version=2026-07-10"
+        assert args.server_timeout == 15
+
 
 class TestApplyConfigFileControlServers:
     _YAML = (
@@ -247,6 +258,17 @@ class TestApplyConfigFileControlServers:
         assert args.control_servers == [
             ControlServer(url="https://yaml-server.com", headers={"Auth": "yaml-token"}, identifier="yaml-user")
         ]
+
+    def test_null_control_servers_key_is_ignored(self, tmp_path):
+        # ``control_servers:`` with no value parses as YAML null; it must be
+        # treated like the key was omitted rather than raising a "must be a
+        # list" error.
+        path = _write_yaml(tmp_path, "control_servers:\nserver_timeout: 15\n")
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.control_servers == []
+        assert args.server_timeout == 15
 
     def test_cli_control_server_replaces_yaml_completely(self, tmp_path):
         # Passing any control-server block flag wipes the YAML array entirely.
@@ -468,6 +490,19 @@ class TestApplyConfigFilePushKeyAndMachineId:
         parser, args = _parse(argv)
         apply_config_file(parser, args, argv)
         assert args.push_key == ""
+
+    def test_null_push_key_and_machine_id_kept_as_none_not_stringified(self, tmp_path):
+        # A key written with no value (``push_key:``) parses as YAML null
+        # (Python None). It must be treated like the key was never in the
+        # file -- keeping the code default of None -- rather than being run
+        # through the str() type converter, which would otherwise produce
+        # the literal string "None".
+        path = _write_yaml(tmp_path, "push_key:\nmachine_id:\n")
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key is None
+        assert args.machine_id is None
 
 
 class TestConfigFilePushKeyPrecedenceOverLegacyFlags:

--- a/tests/unit/test_cli_config_file.py
+++ b/tests/unit/test_cli_config_file.py
@@ -413,3 +413,56 @@ class TestApplyConfigFileFiles:
         parser, args = _parse(argv)
         apply_config_file(parser, args, argv)
         assert args.files == ["/cli/config.json"]
+
+
+class TestApplyConfigFilePushKeyAndMachineId:
+    """--push-key / --machine-id (v0.6+) are ordinary scalar options, so they
+    are settable from the config file through the same generic mechanism as
+    any other flag (see TestApplyConfigFileScalars)."""
+
+    def test_push_key_and_machine_id_loaded_from_yaml(self, tmp_path):
+        path = _write_yaml(tmp_path, "push_key: yaml-push-key\nmachine_id: yaml-machine-id\n")
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key == "yaml-push-key"
+        assert args.machine_id == "yaml-machine-id"
+
+    def test_explicit_cli_push_key_overrides_yaml(self, tmp_path):
+        path = _write_yaml(tmp_path, "push_key: yaml-push-key\n")
+        argv = ["scan", "--config-file", path, "--push-key", "cli-push-key"]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key == "cli-push-key"
+
+    def test_explicit_cli_machine_id_overrides_yaml(self, tmp_path):
+        path = _write_yaml(tmp_path, "machine_id: yaml-machine-id\n")
+        argv = ["scan", "--config-file", path, "--machine-id", "cli-machine-id"]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.machine_id == "cli-machine-id"
+
+    def test_numeric_push_key_coerced_to_string(self, tmp_path):
+        # A bare numeric YAML scalar must be normalized to str, matching what
+        # a real CLI invocation would receive (argv tokens are always strings).
+        path = _write_yaml(tmp_path, "push_key: 12345\n")
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key == "12345"
+        assert isinstance(args.push_key, str)
+
+    def test_numeric_machine_id_coerced_to_string(self, tmp_path):
+        path = _write_yaml(tmp_path, "machine_id: 12345\n")
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.machine_id == "12345"
+        assert isinstance(args.machine_id, str)
+
+    def test_empty_string_push_key_from_yaml_preserved(self, tmp_path):
+        path = _write_yaml(tmp_path, 'push_key: ""\n')
+        argv = ["scan", "--config-file", path]
+        parser, args = _parse(argv)
+        apply_config_file(parser, args, argv)
+        assert args.push_key == ""

--- a/tests/unit/test_cli_interactivity.py
+++ b/tests/unit/test_cli_interactivity.py
@@ -131,6 +131,27 @@ class TestIsInteractiveRun:
         args = Namespace(command="scan")
         assert is_interactive_run(args) is True
 
+    def test_scan_with_push_key_flag_is_non_interactive(self):
+        """--push-key alone (no --control-server) must behave like the deprecated push-key header."""
+        args = _ns(command="scan", push_key="direct-push-key")
+        assert is_interactive_run(args) is False
+
+    def test_scan_without_push_key_flag_is_interactive(self):
+        """Missing --push-key attribute (e.g. inspect parser) falls through safely to True."""
+        assert is_interactive_run(_ns(command="scan")) is True
+
+    def test_evo_with_externally_supplied_push_key_before_minting_is_still_interactive(self):
+        """
+        Before evo() mints its own key, args.control_servers is still empty.
+        An externally-supplied --push-key must not flip is_interactive_run to
+        False here — evo always authenticates with its own minted key, so an
+        outside --push-key must not suppress the upfront tenant/token
+        prompts or the stdio-server stderr streaming default before minting
+        happens.
+        """
+        args = _ns(command="evo", control_servers=[], push_key="attacker-or-stale-key")
+        assert is_interactive_run(args) is True
+
 
 class TestIsInteractiveRunMatrix:
     """
@@ -414,6 +435,22 @@ class TestDecideHandshake:
         # evo is outside the allowlist → safe-default skip.
         assert decide_handshake(Namespace(command="evo")).do_stdio_handshake is False
 
+    # -- --push-key flag must behave like a control-server push-key header --
+
+    def test_scan_with_push_key_flag_skips_handshake_like_deprecated_header(self):
+        """--push-key alone (no --control-server) must match the
+        `x-client-id`-header behavior it replaces: no handshake, no consent."""
+        decision = decide_handshake(_ns(command="scan", push_key="direct-push-key"))
+        assert decision.do_stdio_handshake is False
+        assert decision.collect_consent is False
+
+    def test_scan_with_push_key_flag_and_dangerous_still_handshakes(self):
+        """--dangerously-run-mcp-servers overrides --push-key the same way it
+        overrides the deprecated header-derived push key."""
+        decision = decide_handshake(_ns(command="scan", push_key="direct-push-key", dangerously_run_mcp_servers=True))
+        assert decision.do_stdio_handshake is True
+        assert decision.collect_consent is False
+
 
 class TestEnforceConsentRequirements:
     def test_non_ci_run_is_not_gated(self):
@@ -603,6 +640,16 @@ class TestResolveServerIoDefault:
     def test_missing_attribute_is_treated_as_unset(self):
         """getattr default of None applies even when the attribute isn't on the namespace."""
         args = Namespace(command="scan", control_servers=[])
+        resolve_server_io_default(args)
+        assert args.suppress_mcpserver_io is False
+
+    def test_evo_with_push_key_before_minting_resolves_stream_stderr_default(self):
+        """
+        Same reasoning as ``test_evo_with_externally_supplied_push_key_before_minting_is_still_interactive``:
+        an externally-supplied --push-key must not affect the resolved
+        default before evo() has minted and injected its own key.
+        """
+        args = _ns(command="evo", control_servers=[], push_key="attacker-or-stale-key", suppress_mcpserver_io=None)
         resolve_server_io_default(args)
         assert args.suppress_mcpserver_io is False
 

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from agent_scan.cli import MissingIdentifierError, parse_control_servers
+from agent_scan.cli import MissingIdentifierError, parse_control_servers, warn_deprecated_control_flags
 from agent_scan.models import ControlServer, InspectedPath
 
 
@@ -235,6 +235,198 @@ class TestSkillsFlag:
         assert self._parse(["--no-skills", "--skills"]) is True
 
 
+class TestPushKeyMachineIdArguments:
+    """--push-key / --machine-id: standalone replacements for
+    --control-server-H's x-client-id header and --control-identifier."""
+
+    def _parse(self, extra_argv: list[str]) -> object:
+        import argparse
+
+        from agent_scan.cli import add_control_server_arguments
+
+        parser = argparse.ArgumentParser()
+        add_control_server_arguments(parser)
+        return parser.parse_args(extra_argv)
+
+    def test_push_key_alone_parses(self):
+        args = self._parse(["--push-key", "my-secret-key"])
+        assert args.push_key == "my-secret-key"
+        assert args.machine_id is None
+
+    def test_machine_id_alone_parses(self):
+        args = self._parse(["--machine-id", "host-42"])
+        assert args.machine_id == "host-42"
+        assert args.push_key is None
+
+    def test_push_key_and_machine_id_together_parse_independently(self):
+        args = self._parse(["--push-key", "my-secret-key", "--machine-id", "host-42"])
+        assert args.push_key == "my-secret-key"
+        assert args.machine_id == "host-42"
+
+    def test_neither_flag_defaults_to_none(self):
+        args = self._parse([])
+        assert args.push_key is None
+        assert args.machine_id is None
+        assert args.control_server_H is None
+        assert args.control_identifier is None
+
+
+class TestEffectiveValueResolution:
+    """_effective_push_key / _effective_identifier resolve the new flag over
+    the deprecated one, using an explicit `is not None` check rather than
+    truthiness so an explicitly-passed empty string is honored as-is
+    instead of silently falling back to the legacy value."""
+
+    def test_explicit_empty_push_key_does_not_fall_back_to_legacy_header(self):
+        from argparse import Namespace
+
+        from agent_scan.cli import _effective_push_key
+
+        args = Namespace(
+            command="scan",
+            push_key="",
+            control_servers=[
+                ControlServer(url="https://s.com", headers={"x-client-id": "legacy-key"}, identifier="id1")
+            ],
+        )
+        assert _effective_push_key(args) == ""
+
+    def test_explicit_empty_machine_id_does_not_fall_back_to_legacy_identifier(self):
+        from argparse import Namespace
+
+        from agent_scan.cli import _effective_identifier
+
+        args = Namespace(
+            machine_id="",
+            control_servers=[ControlServer(url="https://s.com", headers={}, identifier="legacy-id")],
+        )
+        assert _effective_identifier(args) == ""
+
+    def test_missing_push_key_falls_back_to_legacy_header(self):
+        from argparse import Namespace
+
+        from agent_scan.cli import _effective_push_key
+
+        args = Namespace(
+            command="scan",
+            control_servers=[
+                ControlServer(url="https://s.com", headers={"x-client-id": "legacy-key"}, identifier="id1")
+            ],
+        )
+        assert _effective_push_key(args) == "legacy-key"
+
+
+class TestDeprecationWarnings:
+    """Old --control-server-H / --control-identifier still work, but emit a
+    one-time-per-invocation stderr warning pointing at --push-key /
+    --machine-id. --control-server-H only warns when it's actually used for
+    the deprecated x-client-id push-key trick, since it's otherwise a
+    generic "additional header" flag; --control-identifier warns on any
+    use."""
+
+    def _parse(self, extra_argv: list[str]) -> object:
+        import argparse
+
+        from agent_scan.cli import add_control_server_arguments, parse_control_servers
+
+        parser = argparse.ArgumentParser()
+        add_control_server_arguments(parser)
+        args = parser.parse_args(extra_argv)
+        # Mirrors main(): control_servers is attached from the raw argv
+        # before warn_deprecated_control_flags is called.
+        args.control_servers = parse_control_servers(extra_argv)
+        return args
+
+    def test_control_server_h_alone_warns_only_about_push_key(self, capsys):
+        args = self._parse(["--control-server-H", "x-client-id:abc"])
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert "--control-server-H" in captured.err
+        assert "--push-key" in captured.err
+        assert "--control-identifier" not in captured.err
+        assert "--machine-id" not in captured.err
+
+    def test_control_identifier_alone_warns_only_about_machine_id(self, capsys):
+        args = self._parse(["--control-identifier", "user1"])
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert "--control-identifier" in captured.err
+        assert "--machine-id" in captured.err
+        assert "--control-server-H" not in captured.err
+        assert "--push-key" not in captured.err
+
+    def test_both_old_flags_together_emit_both_warnings(self, capsys):
+        args = self._parse(["--control-server-H", "x-client-id:abc", "--control-identifier", "user1"])
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert "--control-server-H" in captured.err
+        assert "--push-key" in captured.err
+        assert "--control-identifier" in captured.err
+        assert "--machine-id" in captured.err
+
+    def test_new_flags_alone_emit_no_warning(self, capsys):
+        args = self._parse(["--push-key", "key", "--machine-id", "id"])
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_neither_old_nor_new_flag_emits_no_warning(self, capsys):
+        args = self._parse([])
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_old_and_new_together_still_warns(self, capsys):
+        """Using --push-key doesn't suppress the warning for a still-present old flag."""
+        args = self._parse(["--control-server-H", "x-client-id:abc", "--push-key", "new-key"])
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert "--control-server-H" in captured.err
+        assert "--control-identifier" not in captured.err
+
+    def test_control_server_h_with_unrelated_header_emits_no_warning(self, capsys):
+        """--control-server-H is a generic 'additional header' flag; using it
+        for a header unrelated to the x-client-id push-key trick must not
+        trigger the --push-key deprecation warning."""
+        args = self._parse(
+            [
+                "--control-server",
+                "https://s1.com",
+                "--control-server-H",
+                "X-Custom: value",
+                "--control-identifier",
+                "id1",
+            ]
+        )
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert "--control-server-H" not in captured.err
+        assert "--push-key" not in captured.err
+
+    def test_control_identifier_with_multiple_control_servers_still_warns(self, capsys):
+        """--control-identifier warns on any use, even in a legitimate
+        multi-control-server setup where --machine-id (a single scalar
+        value) couldn't actually replace the distinct per-server
+        identifiers -- the warning is a nudge for the common single-server
+        case, not a precise migration guarantee."""
+        args = self._parse(
+            [
+                "--control-server",
+                "https://s1.com",
+                "--control-identifier",
+                "id1",
+                "--control-server",
+                "https://s2.com",
+                "--control-identifier",
+                "id2",
+            ]
+        )
+        warn_deprecated_control_flags(args)
+        captured = capsys.readouterr()
+        assert "--control-identifier" in captured.err
+        assert "--machine-id" in captured.err
+
+
 class TestControlServerHeaderParsing:
     """Test suite for header parsing in control servers."""
 
@@ -354,6 +546,232 @@ class TestControlServerUploadIntegration:
             mock_pipeline.assert_called_once()
             push_args = mock_pipeline.call_args[0][2]
             assert len(push_args.control_servers) == 0
+
+    @pytest.mark.asyncio
+    async def test_push_key_flag_alone_passed_to_push_args(self):
+        """--push-key alone (no --control-server) reaches PushArgs.push_key."""
+        from argparse import Namespace
+
+        from agent_scan.cli import run_scan
+
+        mock_result = InspectedPath(path="/test/path")
+
+        with patch(
+            "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]
+        ) as mock_pipeline:
+            args = Namespace(
+                verification_H=None,
+                verbose=False,
+                scan_all_users=False,
+                server_timeout=10,
+                files=[],
+                mcp_oauth_tokens_path=None,
+                analysis_url="https://test.com/analysis",
+                skip_ssl_verify=False,
+                control_servers=[],
+                push_key="direct-push-key",
+            )
+
+            await run_scan(args, mode="scan")
+
+            push_args = mock_pipeline.call_args[0][2]
+            assert push_args.control_servers == []
+            assert push_args.push_key == "direct-push-key"
+
+    @pytest.mark.asyncio
+    async def test_machine_id_flag_alone_passed_to_analyze_args_identifier(self):
+        """--machine-id alone (no --control-server) reaches AnalyzeArgs.identifier."""
+        from argparse import Namespace
+
+        from agent_scan.cli import run_scan
+
+        mock_result = InspectedPath(path="/test/path")
+
+        with (
+            patch("agent_scan.cli.collect_consent", return_value=set()),
+            patch(
+                "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]
+            ) as mock_pipeline,
+        ):
+            args = Namespace(
+                verification_H=None,
+                verbose=False,
+                scan_all_users=False,
+                server_timeout=10,
+                files=[],
+                mcp_oauth_tokens_path=None,
+                analysis_url="https://test.com/analysis",
+                skip_ssl_verify=False,
+                control_servers=[],
+                machine_id="host-42",
+            )
+
+            await run_scan(args, mode="scan")
+
+            analyze_args = mock_pipeline.call_args[0][1]
+            assert analyze_args.identifier == "host-42"
+
+    @pytest.mark.asyncio
+    async def test_old_control_server_flags_still_work_without_new_flags(self):
+        """Old --control-server-H / --control-identifier still function unchanged
+        when --push-key / --machine-id are absent from args entirely.
+        push_key is now resolved once in run_scan (via _effective_push_key)
+        and lands on PushArgs already resolved, so it carries the header-
+        derived value rather than None."""
+        from argparse import Namespace
+
+        from agent_scan.cli import run_scan
+
+        mock_result = InspectedPath(path="/test/path")
+
+        with patch(
+            "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]
+        ) as mock_pipeline:
+            args = Namespace(
+                verification_H=None,
+                verbose=False,
+                scan_all_users=False,
+                server_timeout=10,
+                files=[],
+                mcp_oauth_tokens_path=None,
+                analysis_url="https://test.com/analysis",
+                skip_ssl_verify=False,
+                control_servers=[
+                    ControlServer(
+                        url="https://server1.com", headers={"x-client-id": "old-push-key"}, identifier="old-id"
+                    )
+                ],
+            )
+
+            await run_scan(args, mode="scan")
+
+            push_args = mock_pipeline.call_args[0][2]
+            analyze_args = mock_pipeline.call_args[0][1]
+            assert push_args.push_key == "old-push-key"
+            assert analyze_args.identifier == "old-id"
+
+    @pytest.mark.asyncio
+    async def test_new_flags_take_precedence_over_old_when_both_given(self):
+        """When both old and new flags are supplied for the same concept, the
+        new flag's value wins."""
+        from argparse import Namespace
+
+        from agent_scan.cli import run_scan
+
+        mock_result = InspectedPath(path="/test/path")
+
+        with patch(
+            "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]
+        ) as mock_pipeline:
+            args = Namespace(
+                verification_H=None,
+                verbose=False,
+                scan_all_users=False,
+                server_timeout=10,
+                files=[],
+                mcp_oauth_tokens_path=None,
+                analysis_url="https://test.com/analysis",
+                skip_ssl_verify=False,
+                control_servers=[
+                    ControlServer(
+                        url="https://server1.com", headers={"x-client-id": "old-push-key"}, identifier="old-id"
+                    )
+                ],
+                push_key="new-push-key",
+                machine_id="new-id",
+            )
+
+            await run_scan(args, mode="scan")
+
+            push_args = mock_pipeline.call_args[0][2]
+            analyze_args = mock_pipeline.call_args[0][1]
+            assert push_args.push_key == "new-push-key"
+            assert analyze_args.identifier == "new-id"
+
+    @pytest.mark.asyncio
+    async def test_evo_command_push_key_flag_is_ignored_in_favor_of_control_servers(self):
+        """On the evo command, run_scan must never let an externally-supplied
+        --push-key override the key evo minted and injected into
+        args.control_servers — _effective_push_key ignores args.push_key
+        entirely for command == 'evo'."""
+        from argparse import Namespace
+
+        from agent_scan.cli import run_scan
+
+        mock_result = InspectedPath(path="/test/path")
+
+        with (
+            patch("agent_scan.cli.collect_consent", return_value=set()),
+            patch(
+                "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]
+            ) as mock_pipeline,
+        ):
+            args = Namespace(
+                command="evo",
+                verification_H=None,
+                verbose=False,
+                scan_all_users=False,
+                server_timeout=10,
+                files=[],
+                mcp_oauth_tokens_path=None,
+                analysis_url="https://test.com/analysis",
+                skip_ssl_verify=False,
+                control_servers=[
+                    ControlServer(
+                        url="https://push.example/scan", headers={"x-client-id": "minted-key"}, identifier="host1"
+                    )
+                ],
+                push_key="attacker-or-stale-key",
+            )
+
+            await run_scan(args, mode="scan")
+
+            push_args = mock_pipeline.call_args[0][2]
+            assert push_args.push_key == "minted-key"
+
+    @pytest.mark.asyncio
+    async def test_evo_mints_and_uses_its_own_push_key_end_to_end(self):
+        """evo() mints its own client_id and must use it for the scan even
+        if the caller separately supplied --push-key; the externally
+        supplied key must never reach PushArgs.push_key."""
+        from argparse import Namespace
+
+        from agent_scan.cli import evo
+
+        mock_result = InspectedPath(path="/test/path")
+        args = Namespace(
+            command="evo",
+            push_key="attacker-or-stale-key",
+            verification_H=None,
+            verbose=False,
+            scan_all_users=False,
+            server_timeout=10,
+            files=[],
+            mcp_oauth_tokens_path=None,
+            analysis_url="https://test.com/analysis",
+            skip_ssl_verify=False,
+            dangerously_run_mcp_servers=False,
+            suppress_mcpserver_io=None,
+            ci=False,
+        )
+
+        with (
+            patch("builtins.input", side_effect=["tenant-1", "token-1"]),
+            patch("agent_scan.pushkeys.mint_push_key", return_value="minted-key"),
+            patch("agent_scan.pushkeys.revoke_push_key") as mock_revoke,
+            patch(
+                "agent_scan.cli.discover_clients_to_inspect", new_callable=AsyncMock, return_value=([], [], [])
+            ),
+            patch("agent_scan.cli.collect_consent", return_value=set()),
+            patch(
+                "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]
+            ) as mock_pipeline,
+        ):
+            await evo(args)
+
+        push_args = mock_pipeline.call_args[0][2]
+        assert push_args.push_key == "minted-key"
+        mock_revoke.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_skip_ssl_verify_passed_to_pipeline(self):

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -775,9 +775,7 @@ class TestControlServerUploadIntegration:
             patch("builtins.input", side_effect=["tenant-1", "token-1"]),
             patch("agent_scan.pushkeys.mint_push_key", return_value="minted-key"),
             patch("agent_scan.pushkeys.revoke_push_key") as mock_revoke,
-            patch(
-                "agent_scan.cli.discover_clients_to_inspect", new_callable=AsyncMock, return_value=([], [], [])
-            ),
+            patch("agent_scan.cli.discover_clients_to_inspect", new_callable=AsyncMock, return_value=([], [], [])),
             patch("agent_scan.cli.collect_consent", return_value=set()),
             patch(
                 "agent_scan.cli.inspect_analyze_push_pipeline", new_callable=AsyncMock, return_value=[mock_result]

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from agent_scan.models import InspectedPath
+from agent_scan.models import ControlServer, InspectedPath
 from agent_scan.models.api.v20260710 import ScanPathResponse, ScanResponse
 from agent_scan.pipelines import AnalyzeArgs, InspectArgs, PushArgs, inspect_analyze_push_pipeline
 
@@ -29,3 +29,116 @@ async def test_scan_pipeline_returns_api_response():
     assert result is response
     inspect_pipeline.assert_awaited_once()
     assert analyze.await_args.args[0] is inspected_paths
+
+
+@pytest.mark.asyncio
+async def test_push_args_push_key_passed_through_verbatim():
+    """PushArgs.push_key is forwarded to analyze_machine exactly as given;
+    precedence between --push-key and the deprecated --control-server-H
+    x-client-id header is resolved upstream by the caller (cli.py's
+    _effective_push_key), not by this pipeline."""
+    inspected_paths = [InspectedPath(client="cursor", path="/config")]
+    response = ScanResponse(scan_path_responses=[ScanPathResponse(client="cursor", path="/config")])
+
+    with (
+        patch(
+            "agent_scan.pipelines.inspect_pipeline",
+            new_callable=AsyncMock,
+            return_value=(inspected_paths, ["alice"]),
+        ),
+        patch("agent_scan.pipelines.analyze_machine", new_callable=AsyncMock, return_value=response) as analyze,
+    ):
+        await inspect_analyze_push_pipeline(
+            InspectArgs(timeout=10, tokens=[], paths=[]),
+            AnalyzeArgs(analysis_url="https://test.example/api"),
+            PushArgs(
+                control_servers=[
+                    ControlServer(url="https://server1.com", headers={"x-client-id": "old-key"}, identifier="old-id")
+                ],
+                push_key="new-key",
+                version="0.6.0",
+            ),
+        )
+
+    assert analyze.await_args.kwargs["push_key"] == "new-key"
+
+
+@pytest.mark.asyncio
+async def test_push_args_push_key_none_is_not_derived_from_control_server_header():
+    """If the caller passes push_key=None, this pipeline does NOT fall back
+    to deriving it from the control_servers x-client-id header itself —
+    that resolution is the caller's responsibility (see cli.py's
+    _effective_push_key). A caller that skips resolving it gets None
+    forwarded, not a silently-derived value."""
+    inspected_paths = [InspectedPath(client="cursor", path="/config")]
+    response = ScanResponse(scan_path_responses=[ScanPathResponse(client="cursor", path="/config")])
+
+    with (
+        patch(
+            "agent_scan.pipelines.inspect_pipeline",
+            new_callable=AsyncMock,
+            return_value=(inspected_paths, ["alice"]),
+        ),
+        patch("agent_scan.pipelines.analyze_machine", new_callable=AsyncMock, return_value=response) as analyze,
+    ):
+        await inspect_analyze_push_pipeline(
+            InspectArgs(timeout=10, tokens=[], paths=[]),
+            AnalyzeArgs(analysis_url="https://test.example/api"),
+            PushArgs(
+                control_servers=[
+                    ControlServer(url="https://server1.com", headers={"x-client-id": "old-key"}, identifier="old-id")
+                ],
+                version="0.6.0",
+            ),
+        )
+
+    assert analyze.await_args.kwargs["push_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_skip_pushing_true_when_push_key_set_without_control_servers():
+    """--push-key alone (no --control-server) must still suppress the
+    default push behavior via X-Push: skip, matching the header-derived
+    push-key flow where control_servers was always non-empty."""
+    inspected_paths = [InspectedPath(client="cursor", path="/config")]
+    response = ScanResponse(scan_path_responses=[ScanPathResponse(client="cursor", path="/config")])
+
+    with (
+        patch(
+            "agent_scan.pipelines.inspect_pipeline",
+            new_callable=AsyncMock,
+            return_value=(inspected_paths, ["alice"]),
+        ),
+        patch("agent_scan.pipelines.analyze_machine", new_callable=AsyncMock, return_value=response) as analyze,
+    ):
+        await inspect_analyze_push_pipeline(
+            InspectArgs(timeout=10, tokens=[], paths=[]),
+            AnalyzeArgs(analysis_url="https://test.example/api"),
+            PushArgs(control_servers=[], push_key="direct-push-key", version="0.6.0"),
+        )
+
+    assert analyze.await_args.kwargs["skip_pushing"] is True
+
+
+@pytest.mark.asyncio
+async def test_skip_pushing_false_when_neither_control_servers_nor_push_key_set():
+    """A plain scan with no control servers and no push key must not set
+    X-Push: skip."""
+    inspected_paths = [InspectedPath(client="cursor", path="/config")]
+    response = ScanResponse(scan_path_responses=[ScanPathResponse(client="cursor", path="/config")])
+
+    with (
+        patch(
+            "agent_scan.pipelines.inspect_pipeline",
+            new_callable=AsyncMock,
+            return_value=(inspected_paths, ["alice"]),
+        ),
+        patch("agent_scan.pipelines.analyze_machine", new_callable=AsyncMock, return_value=response) as analyze,
+    ):
+        await inspect_analyze_push_pipeline(
+            InspectArgs(timeout=10, tokens=[], paths=[]),
+            AnalyzeArgs(analysis_url="https://test.example/api"),
+            PushArgs(control_servers=[], version="0.6.0"),
+        )
+
+    assert analyze.await_args.kwargs["skip_pushing"] is False

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -142,3 +142,28 @@ async def test_skip_pushing_false_when_neither_control_servers_nor_push_key_set(
         )
 
     assert analyze.await_args.kwargs["skip_pushing"] is False
+
+
+@pytest.mark.asyncio
+async def test_skip_pushing_true_when_push_key_explicitly_empty_string():
+    """An explicit empty-string --push-key (used to override a legacy header,
+    see cli._effective_push_key's ``is not None`` semantics) must still be
+    treated as "a push key was set" for skip_pushing, not as falsy/unset."""
+    inspected_paths = [InspectedPath(client="cursor", path="/config")]
+    response = ScanResponse(scan_path_responses=[ScanPathResponse(client="cursor", path="/config")])
+
+    with (
+        patch(
+            "agent_scan.pipelines.inspect_pipeline",
+            new_callable=AsyncMock,
+            return_value=(inspected_paths, ["alice"]),
+        ),
+        patch("agent_scan.pipelines.analyze_machine", new_callable=AsyncMock, return_value=response) as analyze,
+    ):
+        await inspect_analyze_push_pipeline(
+            InspectArgs(timeout=10, tokens=[], paths=[]),
+            AnalyzeArgs(analysis_url="https://test.example/api"),
+            PushArgs(control_servers=[], push_key="", version="0.6.0"),
+        )
+
+    assert analyze.await_args.kwargs["skip_pushing"] is True

--- a/tests/unit/test_pipelines.py
+++ b/tests/unit/test_pipelines.py
@@ -145,10 +145,16 @@ async def test_skip_pushing_false_when_neither_control_servers_nor_push_key_set(
 
 
 @pytest.mark.asyncio
-async def test_skip_pushing_true_when_push_key_explicitly_empty_string():
-    """An explicit empty-string --push-key (used to override a legacy header,
-    see cli._effective_push_key's ``is not None`` semantics) must still be
-    treated as "a push key was set" for skip_pushing, not as falsy/unset."""
+async def test_skip_pushing_false_when_push_key_explicitly_empty_string():
+    """An explicit empty-string --push-key (used only to override a legacy
+    header without adopting it, see cli._effective_push_key's ``is not None``
+    resolution) is not a real push key: it must be treated as falsy/unset for
+    skip_pushing, consistent with every other consumer of the resolved push
+    key (analyze_machine's own ``if push_key:`` header guard, and cli.py's
+    is_interactive_run / decide_handshake, both of which use ``bool(...)``).
+    The ``is not None`` check belongs only to source-precedence resolution
+    inside _effective_push_key itself, not to behavior driven by the
+    resolved value."""
     inspected_paths = [InspectedPath(client="cursor", path="/config")]
     response = ScanResponse(scan_path_responses=[ScanPathResponse(client="cursor", path="/config")])
 
@@ -166,4 +172,4 @@ async def test_skip_pushing_true_when_push_key_explicitly_empty_string():
             PushArgs(control_servers=[], push_key="", version="0.6.0"),
         )
 
-    assert analyze.await_args.kwargs["skip_pushing"] is True
+    assert analyze.await_args.kwargs["skip_pushing"] is False


### PR DESCRIPTION
## Summary

- Adds standalone `--push-key` and `--machine-id` flags on `scan`/`inspect`/`evo`, replacing the `x-client-id` header buried in `--control-server-H` and replacing `--control-identifier`. No block/pairing semantics — each is independent and optional.
- `--control-server-H`/`--control-identifier` keep working exactly as before, but now print a one-time stderr deprecation warning (per flag actually used) pointing at the new replacement.
- If both an old and new flag are given for the same concept in one invocation, the **new flag's value wins**; the old flag's warning still fires.

## Note for reviewers

- No deprecation warning added for `--control-server`. Should it be added and suggest `--analysis-url` instead?
- The `PUSH_KEY` env var used by `guard` is a separate, unrelated mechanism (guard hook generation). The similar name is coincidental — no functional convergence intended.
- `--push-key` was already present in `redact.py`'s sensitive-flag list and already correctly redacted in logs; no changes needed there.

## Test plan

- [x] `--push-key` alone → works, no warning
- [x] `--machine-id` alone → works, no warning
- [x] `--control-server-H` alone → still functional, warns (points to `--push-key` only)
- [x] `--control-identifier` alone → still functional, warns (points to `--machine-id` only)
- [x] Both old flags together → both warnings fire
- [x] Old + new for the same concept → new value wins, old warning still fires
- [x] Neither given → no warnings, no behavior change
- [x] `--push-key` alone correctly skips interactive consent/handshake, matching current `x-client-id`-header behavior
- [x] Full unit suite passes; `ruff check`/`ruff format` clean