### PR TITLE
feat: use frontmatter name as skill name

### DIFF
--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -19,6 +19,7 @@ from agent_scan.models import (
     ScanError,
     ServerHTTPError,
     ServerStartupError,
+    SkillFile,
     SkillScanError,
     StdioServer,
     TokenAndClientInfo,
@@ -27,7 +28,12 @@ from agent_scan.models import (
     UserDeclinedError,
 )
 from agent_scan.signed_binary import check_server_signature
-from agent_scan.skill_client import SkillInspectionError, collect_skill_files, inspect_skills_dir
+from agent_scan.skill_client import (
+    SkillInspectionError,
+    collect_skill_files,
+    inspect_skills_dir,
+    resolve_skill_name,
+)
 from agent_scan.traffic_capture import TrafficCapture
 from agent_scan.utils import get_relative_path
 from agent_scan.well_known_clients import expand_path
@@ -206,20 +212,12 @@ def find_relevant_token(tokens: list[TokenAndClientInfo], name: str) -> TokenAnd
 
 
 def _inspect_skill(skill: DiscoveredSkill) -> InspectedSkill:
+    files: list[SkillFile] = []
+    skill_name = skill.name
+    error: ScanError | None = None
     try:
-        files = collect_skill_files(skill.path, validate_skill_md_frontmatter=True)
-        error = None
-    except SkillInspectionError as inspection_error:
-        files = []
-        error = ScanError(
-            message="could not inspect skill",
-            exception=str(inspection_error),
-            traceback=traceback.format_exc(),
-            is_failure=True,
-            category="skill_scan_error",
-        )
+        files = collect_skill_files(skill.path)
     except Exception as collection_error:
-        files = []
         error = ScanError(
             message="could not collect skill files",
             exception=str(collection_error),
@@ -227,8 +225,28 @@ def _inspect_skill(skill: DiscoveredSkill) -> InspectedSkill:
             is_failure=True,
             category="skill_scan_error",
         )
+    else:
+        try:
+            skill_name = resolve_skill_name(skill)
+            error = None
+        except SkillInspectionError as inspection_error:
+            error = ScanError(
+                message="could not inspect skill",
+                exception=str(inspection_error),
+                traceback=traceback.format_exc(),
+                is_failure=True,
+                category="skill_scan_error",
+            )
+        except Exception as inspection_error:
+            error = ScanError(
+                message="could not inspect skill",
+                exception=str(inspection_error),
+                traceback=traceback.format_exc(),
+                is_failure=True,
+                category="skill_scan_error",
+            )
     return InspectedSkill(
-        name=_inspection_component_name(skill.name, "skill", skill.path),
+        name=_inspection_component_name(skill_name, "skill", skill.path),
         installation_path=skill.path,
         files=files,
         error=error,

--- a/src/agent_scan/models/api/v20260710.py
+++ b/src/agent_scan/models/api/v20260710.py
@@ -69,7 +69,15 @@ class McpServerRequest(BaseModel):
 
 
 class SkillRequest(BaseModel):
-    name: str
+    name: str = Field(
+        description=(
+            "The unique name of the skill. For directory-based skills, this is the 'name' field "
+            "extracted from the YAML frontmatter of the SKILL.md file (falling back to the directory "
+            "name on disk if unavailable, e.g. on error). For single-file command-based skills, this "
+            "is the namespaced command identifier (e.g., 'git:commit' for "
+            "'~/.claude/commands/git/commit.md')."
+        )
+    )
     installation_path: str
     files: list[SkillFile] = Field(default_factory=list)
     error: ScanError | None = None
@@ -220,7 +228,15 @@ class SkillFileSummary(BaseModel):
 
 
 class SkillRiskResponse(BaseModel):
-    name: str
+    name: str = Field(
+        description=(
+            "The unique name of the skill. For directory-based skills, this is the 'name' field "
+            "extracted from the YAML frontmatter of the SKILL.md file (falling back to the directory "
+            "name on disk if unavailable, e.g. on error). For single-file command-based skills, this "
+            "is the namespaced command identifier (e.g., 'git:commit' for "
+            "'~/.claude/commands/git/commit.md')."
+        )
+    )
     files: list[SkillFileSummary] = Field(default_factory=list)
     risk_indexes: SkillRiskIndexes = Field(default_factory=SkillRiskIndexes)
     error: ScanError | None = None

--- a/src/agent_scan/models/inspect.py
+++ b/src/agent_scan/models/inspect.py
@@ -50,7 +50,9 @@ class InspectedServer(BaseModel):
 class InspectedSkill(BaseModel):
     """The skill data needed by inspect output and backend analysis."""
 
-    name: str
+    name: str = Field(
+        description="Canonical directory-skill name from SKILL.md frontmatter, or the discovered command identifier."
+    )
     installation_path: str
     files: list[SkillFile] = Field(default_factory=list)
     error: ScanError | None = None

--- a/src/agent_scan/models/skill.py
+++ b/src/agent_scan/models/skill.py
@@ -25,6 +25,13 @@ class DiscoveredSkill(BaseModel):
     )
 
 
+class SkillFrontmatter(BaseModel):
+    """Validated identity metadata from a directory skill's SKILL.md file."""
+
+    name: str
+    description: str
+
+
 class SkillFile(BaseModel):
     """An individual file collected from a skill directory."""
 

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -5,7 +5,7 @@ import os
 import yaml
 from yaml.error import YAMLError
 
-from agent_scan.models.skill import DiscoveredSkill, SkillFile
+from agent_scan.models.skill import DiscoveredSkill, SkillFile, SkillFrontmatter
 from agent_scan.redact import redact_text
 from agent_scan.utils import get_relative_path
 
@@ -33,14 +33,27 @@ def get_skill_md_path(path: str) -> str | None:
     return None
 
 
-def _validate_skill_md_frontmatter(content: str, skill_path: str) -> None:
-    """Validate the required identity fields in directory-skill frontmatter."""
-    content_chunks = content.split("---")
-    if len(content_chunks) <= 2:
+def _extract_leading_frontmatter_yaml(content: str) -> str | None:
+    """Return the leading YAML frontmatter block, excluding delimiters."""
+    lines = content.lstrip("\ufeff \t\r\n").splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    closing_delimiter = next(
+        (index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"),
+        None,
+    )
+    if closing_delimiter is None:
+        return None
+    return "\n".join(lines[1:closing_delimiter]).strip()
+
+
+def parse_skill_frontmatter(content: str, skill_path: str) -> SkillFrontmatter:
+    """Parse and validate the required identity metadata in a SKILL.md file."""
+    yaml_content = _extract_leading_frontmatter_yaml(content)
+    if yaml_content is None:
         raise SkillInspectionError(
             f"Invalid SKILL.md file: {skill_path}. Could not find the YAML and the MD parts in the SKILL.md file."
         )
-    yaml_content = content_chunks[1].strip()
     try:
         yaml_data = yaml.safe_load(yaml_content)
     except YAMLError as e:
@@ -55,13 +68,34 @@ def _validate_skill_md_frontmatter(content: str, skill_path: str) -> None:
             raise SkillInspectionError(
                 f"Invalid SKILL.md file: {skill_path}. YAML frontmatter {field} must be a non-empty string."
             )
+    return SkillFrontmatter(
+        name=yaml_data["name"].strip(),
+        description=yaml_data["description"].strip(),
+    )
+
+
+def resolve_skill_name(skill: DiscoveredSkill) -> str:
+    """Resolve a directory skill's raw frontmatter name or preserve a command name."""
+    expanded_path = os.path.expanduser(skill.path)
+    if os.path.isfile(expanded_path):
+        return skill.name
+
+    skill_md_filename = get_skill_md_path(expanded_path)
+    if skill_md_filename is None:
+        raise SkillInspectionError(f"neither SKILL.md nor skill.md file found at path: {skill.path}")
+    skill_md_path = os.path.join(expanded_path, skill_md_filename)
+    try:
+        with open(skill_md_path, encoding="utf-8") as skill_md:
+            content = skill_md.read()
+    except UnicodeDecodeError as error:
+        raise SkillInspectionError(str(error)) from error
+    return parse_skill_frontmatter(content, skill.path).name
 
 
 def _read_skill_file_content(
     full_path: str,
     *,
     allow_binary: bool,
-    skill_path_for_frontmatter_validation: str | None = None,
 ) -> str:
     """Read one skill file's content for the v2026-07-10 request payload.
 
@@ -74,8 +108,6 @@ def _read_skill_file_content(
     try:
         with open(expanded, encoding="utf-8") as f:
             content = f.read()
-        if skill_path_for_frontmatter_validation is not None:
-            _validate_skill_md_frontmatter(content, skill_path_for_frontmatter_validation)
         return redact_text(content) or ""
     except UnicodeDecodeError as error:
         if not allow_binary:
@@ -88,7 +120,7 @@ def _read_skill_file_content(
         return f"{BINARY_FILE_DESCRIPTION_PREFIX}{hasher.hexdigest()}"
 
 
-def collect_skill_files(skill_path: str, *, validate_skill_md_frontmatter: bool = False) -> list[SkillFile]:
+def collect_skill_files(skill_path: str) -> list[SkillFile]:
     """Collect skill files as redacted ``SkillFile`` records for inspection and analysis.
 
     Traverses and reads every file within a skill target without constructing
@@ -125,7 +157,6 @@ def collect_skill_files(skill_path: str, *, validate_skill_md_frontmatter: bool 
         raise ValueError(f"Skill path is not a file or directory: {skill_path}")
 
     files: list[SkillFile] = []
-    found_skill_md = False
     for root, dirs, filenames in os.walk(expanded_path):
         dirs.sort()  # deterministic traversal order across platforms
         if any(os.path.islink(os.path.join(root, dirname)) for dirname in dirs):
@@ -136,22 +167,15 @@ def collect_skill_files(skill_path: str, *, validate_skill_md_frontmatter: bool 
                 raise ValueError("Skill directory must not contain symbolic links")
             relative_path = os.path.relpath(full_path, expanded_path).replace(os.path.sep, "/")
             extension = filename.rsplit(".", 1)[-1].lower()
-            is_skill_md = relative_path.lower() == "skill.md"
-            found_skill_md = found_skill_md or is_skill_md
             files.append(
                 SkillFile(
                     path=relative_path,
                     content=_read_skill_file_content(
                         full_path,
                         allow_binary=extension not in ("md", "py", "js", "ts", "sh"),
-                        skill_path_for_frontmatter_validation=(
-                            skill_path if validate_skill_md_frontmatter and is_skill_md else None
-                        ),
                     ),
                 )
             )
-    if validate_skill_md_frontmatter and not found_skill_md:
-        raise SkillInspectionError(f"neither SKILL.md nor skill.md file found at path: {skill_path}")
     return files
 
 

--- a/tests/e2e/test_inspect.py
+++ b/tests/e2e/test_inspect.py
@@ -225,6 +225,17 @@ class TestInspect:
         assert test_skill["error"] is None
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_inspect_skill_uses_frontmatter_name_in_json(self, agent_scan_cmd, tmp_path):
+        skill_dir = tmp_path / "directory-name"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: frontmatter-name\ndescription: Test skill\n---\n# Instructions")
+
+        result, output = inspect_json(agent_scan_cmd, "--skills", str(skill_dir))
+
+        assert result.returncode == 0, result.stderr
+        assert only_result(output)["skills"][0]["name"] == "frontmatter-name"
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     @pytest.mark.parametrize(
         "skill_path",
         [

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -802,3 +802,50 @@ async def test_inspect_client_collects_skills_and_joins_config_errors(tmp_path):
     assert skill.error is None
 
     assert result.error is not None and "bad config" in (result.error.message or "")
+
+
+@pytest.mark.asyncio
+async def test_inspect_skill_prefers_frontmatter_name_over_directory_name(tmp_path):
+    skill_dir = tmp_path / "random-dir-name"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("---\nname: authentic-skill-name\ndescription: test skill\n---\n# Body")
+    (skill_dir / "helper.py").write_text("print('test')")
+
+    client = ClientToInspect(
+        name="cursor",
+        client_path="/proj",
+        mcp_configs={},
+        skills_dirs={"/proj/skills": [DiscoveredSkill(name="random-dir-name", path=str(skill_dir))]},
+    )
+
+    result = await inspect_client(client, timeout=1, tokens=[], scan_skills=True)
+
+    assert len(result.skills) == 1
+    skill = result.skills[0]
+    assert skill.name == "authentic-skill-name"
+    assert skill.installation_path == str(skill_dir)
+    assert skill.error is None
+
+
+@pytest.mark.asyncio
+async def test_inspect_skill_falls_back_to_directory_name_on_frontmatter_error(tmp_path):
+    skill_dir = tmp_path / "failing-dir-name"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("---\ninvalid: yaml [unterminated\n---\n# Body")
+    (skill_dir / "helper.py").write_text("print('still useful for diagnostics')")
+
+    client = ClientToInspect(
+        name="cursor",
+        client_path="/proj",
+        mcp_configs={},
+        skills_dirs={"/proj/skills": [DiscoveredSkill(name="failing-dir-name", path=str(skill_dir))]},
+    )
+
+    result = await inspect_client(client, timeout=1, tokens=[], scan_skills=True)
+
+    assert len(result.skills) == 1
+    skill = result.skills[0]
+    assert skill.name == "failing-dir-name"
+    assert {file.path for file in skill.files} == {"SKILL.md", "helper.py"}
+    assert skill.error is not None
+    assert skill.error.category == "skill_scan_error"

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -11,13 +11,15 @@ from pathlib import Path
 import pytest
 import yaml
 
-from agent_scan.models.skill import DiscoveredSkill
+from agent_scan.models.skill import DiscoveredSkill, SkillFrontmatter
 from agent_scan.redact import redact_text
 from agent_scan.skill_client import (
     BINARY_FILE_DESCRIPTION_PREFIX,
     SkillInspectionError,
     collect_skill_files,
     inspect_commands_dir,
+    parse_skill_frontmatter,
+    resolve_skill_name,
 )
 from tests.unit._secret_fixtures import synthetic_secret
 
@@ -159,7 +161,7 @@ def test_collect_skill_files_redacts_secrets_from_every_text_file_kind(tmp_path)
     (skill / "run.py").write_text(f'API_KEY = "{_FAKE_SKILL_SECRET}"\n')
     (skill / "config.txt").write_text(f"api_key = {_FAKE_SKILL_SECRET}\n")
 
-    files = collect_skill_files(str(skill), validate_skill_md_frontmatter=True)
+    files = collect_skill_files(str(skill))
 
     assert {file.path for file in files} == {"SKILL.md", "reference.md", "run.py", "config.txt"}
     assert all(_FAKE_SKILL_SECRET not in file.content for file in files)
@@ -215,44 +217,46 @@ def test_collect_skill_files_rejects_symlinked_file_inside_skill(tmp_path):
         collect_skill_files(str(skill))
 
 
-def test_collect_skill_files_requires_skill_md_when_frontmatter_validation_is_enabled(tmp_path):
+def test_resolve_skill_name_requires_skill_md_for_directory_skill(tmp_path):
     skill = tmp_path / "skill"
     skill.mkdir()
     (skill / "reference.md").write_text("# Reference")
-
     with pytest.raises(SkillInspectionError, match=r"neither SKILL\.md nor skill\.md"):
-        collect_skill_files(str(skill), validate_skill_md_frontmatter=True)
+        resolve_skill_name(DiscoveredSkill(name="skill", path=str(skill)))
 
 
-def test_collect_skill_files_rejects_malformed_skill_md_frontmatter_yaml(tmp_path):
+def test_parse_skill_frontmatter_rejects_malformed_yaml(tmp_path):
     skill = tmp_path / "skill"
     skill.mkdir()
     (skill / "SKILL.md").write_text("---\nname: [unterminated\n---\n# Instructions\n")
+    skill_md = collect_skill_files(str(skill))[0]
 
     with pytest.raises(SkillInspectionError, match="invalid yaml"):
-        collect_skill_files(str(skill), validate_skill_md_frontmatter=True)
+        parse_skill_frontmatter(skill_md.content, str(skill))
 
 
 @pytest.mark.parametrize("frontmatter", ["[one, two]", "plain text", "42", "null"])
-def test_collect_skill_files_rejects_non_mapping_skill_md_frontmatter(tmp_path, frontmatter):
+def test_parse_skill_frontmatter_rejects_non_mapping_yaml(tmp_path, frontmatter):
     skill = tmp_path / "skill"
     skill.mkdir()
     (skill / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n# Instructions\n")
+    skill_md = collect_skill_files(str(skill))[0]
 
     with pytest.raises(SkillInspectionError, match="frontmatter must be a mapping"):
-        collect_skill_files(str(skill), validate_skill_md_frontmatter=True)
+        parse_skill_frontmatter(skill_md.content, str(skill))
 
 
 @pytest.mark.parametrize("missing_field", ["name", "description"])
-def test_collect_skill_files_requires_skill_md_frontmatter_identity_fields(tmp_path, missing_field):
+def test_parse_skill_frontmatter_requires_identity_fields(tmp_path, missing_field):
     skill = tmp_path / "skill"
     skill.mkdir()
     frontmatter = {"name": "skill", "description": "Does useful work"}
     del frontmatter[missing_field]
     (skill / "SKILL.md").write_text(f"---\n{yaml.safe_dump(frontmatter)}---\n# Instructions\n")
+    skill_md = collect_skill_files(str(skill))[0]
 
     with pytest.raises(SkillInspectionError, match=rf"Missing {missing_field}"):
-        collect_skill_files(str(skill), validate_skill_md_frontmatter=True)
+        parse_skill_frontmatter(skill_md.content, str(skill))
 
 
 @pytest.mark.parametrize(
@@ -264,11 +268,73 @@ def test_collect_skill_files_requires_skill_md_frontmatter_identity_fields(tmp_p
         ("description", "   "),
     ],
 )
-def test_collect_skill_files_rejects_non_text_skill_md_frontmatter_identity_fields(tmp_path, field, value):
+def test_parse_skill_frontmatter_rejects_non_text_identity_fields(tmp_path, field, value):
     skill = tmp_path / "skill"
     skill.mkdir()
     frontmatter = {"name": "skill", "description": "Does useful work", field: value}
     (skill / "SKILL.md").write_text(f"---\n{yaml.safe_dump(frontmatter)}---\n# Instructions\n")
+    skill_md = collect_skill_files(str(skill))[0]
 
     with pytest.raises(SkillInspectionError, match=rf"{field}.*non-empty string"):
-        collect_skill_files(str(skill), validate_skill_md_frontmatter=True)
+        parse_skill_frontmatter(skill_md.content, str(skill))
+
+
+def test_parse_skill_frontmatter_returns_validated_metadata():
+    assert parse_skill_frontmatter(
+        "---\nname: '  my-skill  '\ndescription: '  Does useful work  '\n---\n# Content",
+        "/skills/my-skill",
+    ) == SkillFrontmatter(
+        name="my-skill",
+        description="Does useful work",
+    )
+
+
+def test_parse_skill_frontmatter_ignores_delimited_body_content():
+    content = "Intro text\n---\nname: not-frontmatter\ndescription: desc\n---\n# Content"
+
+    with pytest.raises(SkillInspectionError, match="Could not find the YAML"):
+        parse_skill_frontmatter(content, "/skills/example")
+
+
+def test_resolve_skill_name_uses_directory_skill_frontmatter(tmp_path):
+    skill_path = tmp_path / "directory-name"
+    skill_path.mkdir()
+    (skill_path / "SKILL.md").write_text("---\nname: authentic-skill\ndescription: desc\n---\n# Content")
+
+    assert resolve_skill_name(DiscoveredSkill(name="directory-name", path=str(skill_path))) == "authentic-skill"
+
+
+def test_resolve_skill_name_preserves_namespaced_command_name(tmp_path):
+    command_path = tmp_path / "commit.md"
+    command_path.write_text("---\nname: custom-git-commit\ndescription: desc\n---\n# Prompt")
+
+    assert resolve_skill_name(DiscoveredSkill(name="git:commit", path=str(command_path))) == "git:commit"
+
+
+def test_resolve_skill_name_reads_frontmatter_before_file_content_redaction(tmp_path):
+    skill_path = tmp_path / "directory-name"
+    skill_path.mkdir()
+    (skill_path / "SKILL.md").write_text(
+        f"---\nname: authentic-skill\ndescription: {_FAKE_SKILL_SECRET}\n---\n# Content"
+    )
+
+    files = collect_skill_files(str(skill_path))
+
+    assert "**REDACTED_SECRET_" in files[0].content
+    assert resolve_skill_name(DiscoveredSkill(name="directory-name", path=str(skill_path))) == "authentic-skill"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "# Prompt without frontmatter",
+        "---\n[invalid yaml\n---",
+        "---\ndescription: no name\n---",
+        "---\nname: 123\n---",
+    ],
+)
+def test_resolve_skill_name_preserves_command_name_regardless_of_frontmatter(tmp_path, content):
+    command_path = tmp_path / "commit.md"
+    command_path.write_text(content)
+
+    assert resolve_skill_name(DiscoveredSkill(name="git:commit", path=str(command_path))) == "git:commit"

--- a/tests/unit/test_verify_api.py
+++ b/tests/unit/test_verify_api.py
@@ -1252,6 +1252,27 @@ class TestBuildScanRequest:
         assert spr.skills[0].installation_path == "/tmp/project/.skills/my-skill"
         assert [f.path for f in spr.skills[0].files] == ["SKILL.md"]
 
+    def test_skill_request_preserves_inspected_skill_name(self):
+        inspected = InspectedPath(
+            client="cursor",
+            path="/tmp/project",
+            skills=[
+                InspectedSkill(
+                    name="canonical-inspected-name",
+                    installation_path="/tmp/project/.skills/dir-name",
+                    files=[
+                        SkillFile(
+                            path="SKILL.md",
+                            content="---\nname: stale-file-name\ndescription: d\n---\n# Body",
+                        )
+                    ],
+                ),
+            ],
+        )
+
+        req = build_scan_request([inspected])
+        assert req.scan_path_requests[0].skills[0].name == "canonical-inspected-name"
+
     def test_top_level_path_is_home_relativized(self):
         absolute_path = os.path.expanduser("~/project/.mcp.json")
         inspected = InspectedPath(client=None, path=absolute_path)


### PR DESCRIPTION
Before v0.6, CLI output has been using the directory name as skill name instead of the frontmatter name. Then in the JSON output this the frontmatter name was represented as a "server name". 

After we moved to v0.6, we kept the legacy behavior and used the directory name. We now change to use the frontmatter name as this is the more authentic name for a skill.