### PR TITLE
fix: support skill symlink files

### DIFF
--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -142,8 +142,6 @@ def collect_skill_files(skill_path: str) -> list[SkillFile]:
     expanded_path = os.path.expanduser(skill_path)
     if not os.path.exists(expanded_path):
         raise FileNotFoundError(f"Skill path does not exist: {skill_path}")
-    if os.path.islink(expanded_path):
-        raise ValueError("Skill path must not be a symbolic link")
 
     if os.path.isfile(expanded_path):
         return [
@@ -157,14 +155,10 @@ def collect_skill_files(skill_path: str) -> list[SkillFile]:
         raise ValueError(f"Skill path is not a file or directory: {skill_path}")
 
     files: list[SkillFile] = []
-    for root, dirs, filenames in os.walk(expanded_path):
+    for root, dirs, filenames in os.walk(expanded_path, followlinks=True):
         dirs.sort()  # deterministic traversal order across platforms
-        if any(os.path.islink(os.path.join(root, dirname)) for dirname in dirs):
-            raise ValueError("Skill directory must not contain symbolic links")
         for filename in sorted(filenames):
             full_path = os.path.join(root, filename)
-            if os.path.islink(full_path):
-                raise ValueError("Skill directory must not contain symbolic links")
             relative_path = os.path.relpath(full_path, expanded_path).replace(os.path.sep, "/")
             extension = filename.rsplit(".", 1)[-1].lower()
             files.append(

--- a/src/agent_scan/skill_client.py
+++ b/src/agent_scan/skill_client.py
@@ -1,6 +1,8 @@
 import hashlib
 import logging
 import os
+import stat
+from collections.abc import Iterator
 
 import yaml
 from yaml.error import YAMLError
@@ -120,6 +122,35 @@ def _read_skill_file_content(
         return f"{BINARY_FILE_DESCRIPTION_PREFIX}{hasher.hexdigest()}"
 
 
+def _walk_skill_regular_files(skill_root: str) -> Iterator[tuple[str, str]]:
+    """Yield lexical relative paths and targets while safely following links."""
+    root_stat = os.stat(skill_root)
+    root_identity = (root_stat.st_dev, root_stat.st_ino)
+    pending = [(skill_root, frozenset({root_identity}))]
+
+    while pending:
+        directory, ancestor_identities = pending.pop()
+        with os.scandir(directory) as entries:
+            sorted_entries = sorted(entries, key=lambda entry: entry.name)
+
+        child_directories: list[tuple[str, frozenset[tuple[int, int]]]] = []
+        for entry in sorted_entries:
+            full_path = entry.path
+            relative_path = os.path.relpath(full_path, skill_root).replace(os.path.sep, "/")
+            target_stat = entry.stat(follow_symlinks=True)
+            if entry.is_dir(follow_symlinks=True):
+                identity = (target_stat.st_dev, target_stat.st_ino)
+                if identity in ancestor_identities:
+                    raise ValueError("Skill directory must not contain a symbolic link cycle")
+                child_directories.append((full_path, ancestor_identities | {identity}))
+            elif stat.S_ISREG(target_stat.st_mode):
+                yield relative_path, full_path
+            else:
+                raise ValueError(f"Skill file is not a regular file: {relative_path}")
+
+        pending.extend(reversed(child_directories))
+
+
 def collect_skill_files(skill_path: str) -> list[SkillFile]:
     """Collect skill files as redacted ``SkillFile`` records for inspection and analysis.
 
@@ -155,21 +186,17 @@ def collect_skill_files(skill_path: str) -> list[SkillFile]:
         raise ValueError(f"Skill path is not a file or directory: {skill_path}")
 
     files: list[SkillFile] = []
-    for root, dirs, filenames in os.walk(expanded_path, followlinks=True):
-        dirs.sort()  # deterministic traversal order across platforms
-        for filename in sorted(filenames):
-            full_path = os.path.join(root, filename)
-            relative_path = os.path.relpath(full_path, expanded_path).replace(os.path.sep, "/")
-            extension = filename.rsplit(".", 1)[-1].lower()
-            files.append(
-                SkillFile(
-                    path=relative_path,
-                    content=_read_skill_file_content(
-                        full_path,
-                        allow_binary=extension not in ("md", "py", "js", "ts", "sh"),
-                    ),
-                )
+    for relative_path, full_path in _walk_skill_regular_files(expanded_path):
+        extension = relative_path.rsplit(".", 1)[-1].lower()
+        files.append(
+            SkillFile(
+                path=relative_path,
+                content=_read_skill_file_content(
+                    full_path,
+                    allow_binary=extension not in ("md", "py", "js", "ts", "sh"),
+                ),
             )
+        )
     return files
 
 

--- a/tests/e2e/test_inspect.py
+++ b/tests/e2e/test_inspect.py
@@ -558,13 +558,13 @@ class TestInspectBehaviorContract:
         assert failed.returncode == 1
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
-    def test_symlinked_skill_file_is_reported_as_skill_error(self, agent_scan_cmd, tmp_path):
-        outside = tmp_path / "outside.txt"
-        outside.write_text("must not be collected")
-        skill = tmp_path / "skill"
-        skill.mkdir()
-        (skill / "SKILL.md").write_text("---\nname: safe-skill\ndescription: safe\n---\n# Safe instructions")
-        (skill / "outside.txt").symlink_to(outside)
+    def test_symlinked_skill_directory_is_inspected(self, agent_scan_cmd, tmp_path):
+        target = tmp_path / "skill-target"
+        target.mkdir()
+        (target / "SKILL.md").write_text("---\nname: linked-skill\ndescription: linked skill\n---\n# Instructions")
+        (target / "reference.md").write_text("# Reference")
+        skill = tmp_path / "skill-link"
+        skill.symlink_to(target, target_is_directory=True)
 
         result, output = inspect_json(
             agent_scan_cmd,
@@ -575,10 +575,12 @@ class TestInspectBehaviorContract:
 
         assert result.returncode == 0
         inspected_skill = only_result(output)["skills"][0]
-        assert inspected_skill["files"] == []
-        assert inspected_skill["error"]["category"] == "skill_scan_error"
-        assert "must not contain symbolic links" in inspected_skill["error"]["exception"]
-        assert "ValueError: Skill directory must not contain symbolic links" in inspected_skill["error"]["traceback"]
+        assert inspected_skill["name"] == "linked-skill"
+        assert {file["path"] for file in inspected_skill["files"]} == {
+            "SKILL.md",
+            "reference.md",
+        }
+        assert inspected_skill["error"] is None
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     def test_multiple_paths_preserve_success_and_failure_results(self, agent_scan_cmd, tmp_path):

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -40,12 +40,12 @@ TEST_CANDIDATE_CLIENT = CandidateClient(
 
 
 @pytest.mark.asyncio
-async def test_inspect_client_rejects_symlink_before_reading_skill(tmp_path):
-    """A symlinked skill file must be rejected before its content is read."""
+async def test_inspect_client_follows_symlinked_skill_md(tmp_path):
     skill_dir = tmp_path / "skill"
     skill_dir.mkdir()
     outside_file = tmp_path / "outside.md"
-    outside_file.write_bytes(b"\xff\xfe")
+    content = "---\nname: linked-skill\ndescription: linked skill\n---\n# Instructions"
+    outside_file.write_text(content)
     (skill_dir / "SKILL.md").symlink_to(outside_file)
     client = ClientToInspect(
         name="cursor",
@@ -57,9 +57,9 @@ async def test_inspect_client_rejects_symlink_before_reading_skill(tmp_path):
     result = await inspect_client(client, timeout=1, tokens=[], scan_skills=True)
 
     assert len(result.skills) == 1
-    assert result.skills[0].files == []
-    assert result.skills[0].error is not None
-    assert result.skills[0].error.exception == "Skill directory must not contain symbolic links"
+    assert result.skills[0].name == "linked-skill"
+    assert [(file.path, file.content) for file in result.skills[0].files] == [("SKILL.md", content)]
+    assert result.skills[0].error is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -195,26 +195,60 @@ def test_collect_skill_files_rejects_path_that_is_not_file_or_directory(tmp_path
         collect_skill_files(str(special_path))
 
 
-def test_collect_skill_files_rejects_symlinked_skill_path(tmp_path):
+def test_collect_skill_files_follows_symlinked_command_file(tmp_path):
     target = tmp_path / "target.md"
-    target.write_text("secret")
+    target.write_text("command instructions")
     link = tmp_path / "skill.md"
     link.symlink_to(target)
 
-    with pytest.raises(ValueError, match="symbolic link"):
-        collect_skill_files(str(link))
+    files = collect_skill_files(str(link))
+
+    assert [(file.path, file.content) for file in files] == [("skill.md", "command instructions")]
 
 
-def test_collect_skill_files_rejects_symlinked_file_inside_skill(tmp_path):
+def test_collect_skill_files_follows_symlinked_skill_directory(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "SKILL.md").write_text("skill instructions")
+    link = tmp_path / "skill"
+    link.symlink_to(target, target_is_directory=True)
+
+    files = collect_skill_files(str(link))
+
+    assert [(file.path, file.content) for file in files] == [("SKILL.md", "skill instructions")]
+
+
+def test_collect_skill_files_follows_symlinked_file_inside_skill(tmp_path):
     outside = tmp_path / "outside.txt"
-    outside.write_text("secret")
+    outside.write_text("linked reference")
     skill = tmp_path / "skill"
     skill.mkdir()
     (skill / "SKILL.md").write_text("instructions")
-    (skill / "outside.txt").symlink_to(outside)
+    (skill / "reference.txt").symlink_to(outside)
 
-    with pytest.raises(ValueError, match="symbolic link"):
-        collect_skill_files(str(skill))
+    by_path = {file.path: file.content for file in collect_skill_files(str(skill))}
+
+    assert by_path == {
+        "SKILL.md": "instructions",
+        "reference.txt": "linked reference",
+    }
+
+
+def test_collect_skill_files_follows_symlinked_directory_inside_skill(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "reference.md").write_text("linked reference")
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("instructions")
+    (skill / "references").symlink_to(outside, target_is_directory=True)
+
+    by_path = {file.path: file.content for file in collect_skill_files(str(skill))}
+
+    assert by_path == {
+        "SKILL.md": "instructions",
+        "references/reference.md": "linked reference",
+    }
 
 
 def test_resolve_skill_name_requires_skill_md_for_directory_skill(tmp_path):

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -6,6 +6,9 @@ Code command files are flat ``*.md`` files, so they need their own scanner
 """
 
 import hashlib
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -249,6 +252,67 @@ def test_collect_skill_files_follows_symlinked_directory_inside_skill(tmp_path):
         "SKILL.md": "instructions",
         "references/reference.md": "linked reference",
     }
+
+
+def _collect_skill_files_in_subprocess(skill_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from agent_scan.skill_client import collect_skill_files; import sys; collect_skill_files(sys.argv[1])",
+            str(skill_path),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=2,
+        check=False,
+    )
+
+
+def test_collect_skill_files_rejects_symlink_cycle(tmp_path):
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("instructions")
+    (skill / "loop").symlink_to(skill, target_is_directory=True)
+
+    result = _collect_skill_files_in_subprocess(skill)
+
+    assert result.returncode != 0
+    assert "symbolic link cycle" in result.stderr
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are not available on this platform")
+def test_collect_skill_files_rejects_symlink_to_fifo(tmp_path):
+    fifo = tmp_path / "input"
+    os.mkfifo(fifo)
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("instructions")
+    (skill / "input.txt").symlink_to(fifo)
+
+    result = _collect_skill_files_in_subprocess(skill)
+
+    assert result.returncode != 0
+    assert "not a regular file" in result.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions required")
+def test_collect_skill_files_propagates_directory_traversal_error(tmp_path):
+    skill = tmp_path / "skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("instructions")
+    unreadable = skill / "unreadable"
+    unreadable.mkdir()
+    unreadable.chmod(0)
+    if os.access(unreadable, os.R_OK):
+        unreadable.chmod(0o700)
+        pytest.skip("Current user can read mode-000 directories")
+
+    try:
+        with pytest.raises(PermissionError):
+            collect_skill_files(str(skill))
+    finally:
+        unreadable.chmod(0o700)
 
 
 def test_resolve_skill_name_requires_skill_md_for_directory_skill(tmp_path):


### PR DESCRIPTION
v0.5.x support symlink skill files but v0.6.0 was treating it as error and reject the skill for analysis. We're brining back the symlink support for v0.6.0.

Out of qodo suggestion we also added circular link check so that the link following is safe.