### PR TITLE
perf: cache secret detection per token to cut scan CPU

### DIFF
--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -9,6 +9,7 @@ This module provides functions to redact sensitive data like:
 - File paths in tracebacks
 """
 
+import functools
 import logging
 import re
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -204,6 +205,24 @@ def _wrap_for_entropy(value: str) -> str:
 # fewer tokens, never one a plugin would flag.
 _PROSE_MAX_LEN = 15
 
+# Line-level fast-path gate for :func:`_redact_secrets_in_line`. A line needs the
+# full (expensive) plugin scan iff it can contain a value any plugin could flag.
+# This is the line-level lift of :func:`_could_be_secret`, expressed as one
+# ``re.search`` so a prose/markdown line is rejected in a single linear pass
+# instead of ``str.split()`` + the per-token plugin battery on every word:
+#   * ``[^a-z \t]`` — any digit, uppercase, quote, ``=``/``:``, punctuation, or
+#     non-ASCII char. Every format detector needs one of these, and the entropy
+#     plugins only match quoted literals (which require a quote char). A line of
+#     lowercase words + spaces/tabs satisfies none of them.
+#   * ``[a-z]{16,}`` — a run of >``_PROSE_MAX_LEN`` lowercase letters. Lowercase
+#     is valid base64 (log2(26) ~= 4.7 > Base64HighEntropyString's 4.5 limit), so
+#     a long lowercase-only token could still be flagged and must not be skipped.
+#     The bound must stay ``_PROSE_MAX_LEN + 1``.
+# If neither branch matches, EVERY token is a short lowercase-ASCII word that
+# ``_could_be_secret`` would already reject, so skipping the line is provably
+# safe for the current plugin set.
+_LINE_NEEDS_SCAN = re.compile(r"[^a-z \t]|[a-z]{" + str(_PROSE_MAX_LEN + 1) + r",}")
+
 
 def _could_be_secret(value: str) -> bool:
     """Cheap O(len) pre-filter: ``True`` for every value any plugin could flag,
@@ -282,6 +301,18 @@ def _detect_secret(value: str, plugins: list | None = None) -> str | None:
         return _detect_secret_in_plugins(value, plugins)
     with transient_settings(_DETECT_SECRETS_CONFIG):
         return _detect_secret_in_plugins(value, list(get_plugins()))
+
+
+@functools.lru_cache(maxsize=200_000)
+def _detect_secret_cached(value: str) -> str | None:
+    """Cache _detect_secret_in_plugins results by token value.
+
+    Skill text repeats the same tokens (prose words, punctuation, keywords)
+    thousands of times per run. Detection depends only on the token and the
+    fixed plugin set (_get_cached_plugins), so the result is the same
+    every time caching by value skips the repeated work without changing output.
+    """
+    return _detect_secret_in_plugins(value, _get_cached_plugins())
 
 
 def _detect_keyword(prev_normalized: str, curr_raw: str) -> str | None:
@@ -542,6 +573,11 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
     Replacements are applied longest-first so a secret that is a substring of
     another does not corrupt the marker inserted for the longer one.
     """
+    # Fast-path gate: skip the whole plugin battery for lines that provably hold
+    # no secret (pure lowercase-ASCII prose). See :data:`_LINE_NEEDS_SCAN`.
+    if not _LINE_NEEDS_SCAN.search(line):
+        return line
+
     replacements: dict[str, str] = {}
 
     # Pass 1: high-entropy detectors on the raw line (catches quoted literals).
@@ -566,7 +602,7 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
             if candidate in replacements:
                 handled = True
                 break
-            plugin_name = _detect_secret(candidate, plugins)
+            plugin_name = _detect_secret_cached(candidate)
             if plugin_name is not None:
                 replacements[candidate] = _redaction_marker(plugin_name)
                 handled = True
@@ -581,7 +617,7 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
         for segment in _TOKEN_SPLIT_DELIMS.split(token):
             if not segment or segment in replacements:
                 continue
-            plugin_name = _detect_secret(segment, plugins)
+            plugin_name = _detect_secret_cached(segment)
             if plugin_name is not None:
                 replacements[segment] = _redaction_marker(plugin_name)
 

--- a/src/agent_scan/redact.py
+++ b/src/agent_scan/redact.py
@@ -136,6 +136,32 @@ def _get_cached_plugins() -> list:
     return _CACHED_PLUGINS
 
 
+def _partition_plugins(plugins: list) -> tuple[list, list]:
+    """Split *plugins* into ``(format_detectors, entropy_detectors)``.
+
+    The two families need different handling in the scan loops, so we sort them
+    once here. ``entropy_detectors`` are the ``HighEntropyStringsPlugin``
+    subclasses; ``format_detectors`` are the rest (AWS, GitHub, etc.). Doing this
+    split once means the hot loops can just iterate the family they need, instead
+    of calling ``isinstance`` on every plugin for every token which is slow and
+    adds up over a large scan.
+    """
+    entropy = [p for p in plugins if isinstance(p, HighEntropyStringsPlugin)]
+    formats = [p for p in plugins if not isinstance(p, HighEntropyStringsPlugin)]
+    return formats, entropy
+
+
+# Process-wide cache of the partitioned plugin lists (see _get_cached_plugins).
+_CACHED_PLUGINS_SPLIT: tuple[list, list] | None = None
+
+
+def _get_cached_plugins_split() -> tuple[list, list]:
+    global _CACHED_PLUGINS_SPLIT
+    if _CACHED_PLUGINS_SPLIT is None:
+        _CACHED_PLUGINS_SPLIT = _partition_plugins(_get_cached_plugins())
+    return _CACHED_PLUGINS_SPLIT
+
+
 def _redaction_marker(plugin_name: str) -> str:
     """Format the redaction marker for a triggering detect-secrets plugin.
 
@@ -205,24 +231,6 @@ def _wrap_for_entropy(value: str) -> str:
 # fewer tokens, never one a plugin would flag.
 _PROSE_MAX_LEN = 15
 
-# Line-level fast-path gate for :func:`_redact_secrets_in_line`. A line needs the
-# full (expensive) plugin scan iff it can contain a value any plugin could flag.
-# This is the line-level lift of :func:`_could_be_secret`, expressed as one
-# ``re.search`` so a prose/markdown line is rejected in a single linear pass
-# instead of ``str.split()`` + the per-token plugin battery on every word:
-#   * ``[^a-z \t]`` — any digit, uppercase, quote, ``=``/``:``, punctuation, or
-#     non-ASCII char. Every format detector needs one of these, and the entropy
-#     plugins only match quoted literals (which require a quote char). A line of
-#     lowercase words + spaces/tabs satisfies none of them.
-#   * ``[a-z]{16,}`` — a run of >``_PROSE_MAX_LEN`` lowercase letters. Lowercase
-#     is valid base64 (log2(26) ~= 4.7 > Base64HighEntropyString's 4.5 limit), so
-#     a long lowercase-only token could still be flagged and must not be skipped.
-#     The bound must stay ``_PROSE_MAX_LEN + 1``.
-# If neither branch matches, EVERY token is a short lowercase-ASCII word that
-# ``_could_be_secret`` would already reject, so skipping the line is provably
-# safe for the current plugin set.
-_LINE_NEEDS_SCAN = re.compile(r"[^a-z \t]|[a-z]{" + str(_PROSE_MAX_LEN + 1) + r",}")
-
 
 def _could_be_secret(value: str) -> bool:
     """Cheap O(len) pre-filter: ``True`` for every value any plugin could flag,
@@ -240,23 +248,24 @@ def _could_be_secret(value: str) -> bool:
     )
 
 
-def _detect_secret_in_plugins(value: str, plugins: list) -> str | None:
-    """Two-pass scan of ``value`` against an already-built ``plugins`` list.
+def _detect_secret_in_plugins(value: str, format_plugins: list, entropy_plugins: list) -> str | None:
+    """Two-pass scan of ``value`` against pre-partitioned plugin lists.
 
     Each plugin family gets the input format it expects:
 
-    1. Named-format detectors (``AWSKeyDetector``, ``GitHubTokenDetector``,
-       etc.) match self-contained format patterns and work on the raw
-       value directly.
-    2. ``HighEntropyStringsPlugin`` subclasses default to scanning quoted
-       string literals (``(['"])(token)(\\1)``); they receive the value
-       wrapped as ``"<value>"``, ``'<value>'``, or ``"<escaped>"`` so
-       their regex tokenizes the whole value, then the entropy ``limit``
-       filter is applied.
+    1. ``format_plugins`` -- named-format detectors (``AWSKeyDetector``,
+       ``GitHubTokenDetector``, etc.) match self-contained format patterns and
+       work on the raw value directly.
+    2. ``entropy_plugins`` -- ``HighEntropyStringsPlugin`` subclasses default to
+       scanning quoted string literals (``(['"])(token)(\\1)``); they receive the
+       value wrapped as ``"<value>"``, ``'<value>'``, or ``"<escaped>"`` so their
+       regex tokenizes the whole value, then the entropy ``limit`` filter applies.
 
-    The caller is responsible for holding an active
-    ``transient_settings(_DETECT_SECRETS_CONFIG)`` context that ``plugins``
-    was built under.
+    Callers pass the split from :func:`_partition_plugins` (usually the cached
+    :func:`_get_cached_plugins_split`) so the per-value hot loop does zero
+    ``isinstance`` work. The caller is responsible for holding an active
+    ``transient_settings(_DETECT_SECRETS_CONFIG)`` context the plugins were built
+    under.
     """
     # Cheap pre-filter: skip the full plugin battery for values that provably
     # match nothing (see :func:`_could_be_secret`). Conservative -- never
@@ -264,16 +273,12 @@ def _detect_secret_in_plugins(value: str, plugins: list) -> str | None:
     if not _could_be_secret(value):
         return None
     # Pass 1: format-based named detectors on the bare value.
-    for plugin in plugins:
-        if isinstance(plugin, HighEntropyStringsPlugin):
-            continue
+    for plugin in format_plugins:
         if plugin.analyze_line(filename="adhoc", line=value, line_number=1):
             return type(plugin).__name__
     # Pass 2: entropy plugins on the quote-wrapped value.
     wrapped = _wrap_for_entropy(value)
-    for plugin in plugins:
-        if not isinstance(plugin, HighEntropyStringsPlugin):
-            continue
+    for plugin in entropy_plugins:
         if plugin.analyze_line(filename="adhoc", line=wrapped, line_number=1):
             return type(plugin).__name__
     return None
@@ -298,9 +303,9 @@ def _detect_secret(value: str, plugins: list | None = None) -> str | None:
     if not value:
         return None
     if plugins is not None:
-        return _detect_secret_in_plugins(value, plugins)
+        return _detect_secret_in_plugins(value, *_partition_plugins(plugins))
     with transient_settings(_DETECT_SECRETS_CONFIG):
-        return _detect_secret_in_plugins(value, list(get_plugins()))
+        return _detect_secret_in_plugins(value, *_partition_plugins(list(get_plugins())))
 
 
 @functools.lru_cache(maxsize=200_000)
@@ -312,7 +317,7 @@ def _detect_secret_cached(value: str) -> str | None:
     fixed plugin set (_get_cached_plugins), so the result is the same
     every time caching by value skips the repeated work without changing output.
     """
-    return _detect_secret_in_plugins(value, _get_cached_plugins())
+    return _detect_secret_in_plugins(value, *_get_cached_plugins_split())
 
 
 def _detect_keyword(prev_normalized: str, curr_raw: str) -> str | None:
@@ -544,7 +549,7 @@ def _unwrapped_token_core(token: str) -> str | None:
 _TOKEN_SPLIT_DELIMS = re.compile(r"[/:.,;@?&#|\\]")
 
 
-def _redact_secrets_in_line(line: str, plugins: list) -> str:
+def _redact_secrets_in_line(line: str, entropy_plugins: list) -> str:
     """Redact secret-bearing substrings within a single line of free text.
 
     Reuses the detect-secrets plugin set in two complementary passes that each
@@ -573,17 +578,10 @@ def _redact_secrets_in_line(line: str, plugins: list) -> str:
     Replacements are applied longest-first so a secret that is a substring of
     another does not corrupt the marker inserted for the longer one.
     """
-    # Fast-path gate: skip the whole plugin battery for lines that provably hold
-    # no secret (pure lowercase-ASCII prose). See :data:`_LINE_NEEDS_SCAN`.
-    if not _LINE_NEEDS_SCAN.search(line):
-        return line
-
     replacements: dict[str, str] = {}
 
     # Pass 1: high-entropy detectors on the raw line (catches quoted literals).
-    for plugin in plugins:
-        if not isinstance(plugin, HighEntropyStringsPlugin):
-            continue
+    for plugin in entropy_plugins:
         for secret in plugin.analyze_line(filename="adhoc", line=line, line_number=1) or []:
             value = getattr(secret, "secret_value", None)
             if value:
@@ -646,8 +644,8 @@ def redact_text(text: str | None) -> str | None:
     """
     if not text:
         return text
-    plugins = _get_cached_plugins()
-    return "\n".join(_redact_secrets_in_line(line, plugins) for line in text.split("\n"))
+    _, entropy_plugins = _get_cached_plugins_split()
+    return "\n".join(_redact_secrets_in_line(line, entropy_plugins) for line in text.split("\n"))
 
 
 def redact_error_text(text: str | None) -> str | None:

--- a/tests/unit/test_redact.py
+++ b/tests/unit/test_redact.py
@@ -619,8 +619,10 @@ class TestRedactText:
         # Force a rebuild for this test regardless of what earlier tests in
         # this process already primed, so the "once" assertion below is
         # meaningful rather than trivially satisfied by the cache already
-        # being warm.
+        # being warm. Both the plugin list and its partitioned form are cached,
+        # so reset both -- otherwise the warm split short-circuits the rebuild.
         monkeypatch.setattr(redact_mod, "_CACHED_PLUGINS", None)
+        monkeypatch.setattr(redact_mod, "_CACHED_PLUGINS_SPLIT", None)
 
         real_transient_settings = redact_mod.transient_settings
         entries = 0

--- a/tests/unit/test_redact_prefilter_equivalence.py
+++ b/tests/unit/test_redact_prefilter_equivalence.py
@@ -92,6 +92,47 @@ def test_prefilter_output_identical_to_unfiltered(seed, monkeypatch):
     assert gated == ungated
 
 
+class _AlwaysMatch:
+    """Stand-in for ``_LINE_NEEDS_SCAN`` that forces every line through the full scan."""
+
+    @staticmethod
+    def search(_line):
+        return True
+
+
+@pytest.mark.parametrize("seed", [1, 7, 42, 20260618, 999999])
+def test_line_gate_output_identical_to_unfiltered(seed, monkeypatch):
+    """The line-level gate (_LINE_NEEDS_SCAN) must skip only lines the full scan
+    would leave unchanged: gate-on output == gate-off output, byte-for-byte."""
+    rng = random.Random(seed)
+    tokens = _build_tokens(rng, 4000)
+    lines, i = [], 0
+    while i < len(tokens):
+        width = rng.randint(1, 12)
+        lines.append(" ".join(tokens[i : i + width]))
+        i += width
+    text = "\n".join(lines)
+
+    gated = redact_text(text)  # real _LINE_NEEDS_SCAN
+
+    monkeypatch.setattr(redact_mod, "_LINE_NEEDS_SCAN", _AlwaysMatch)  # disable line gate
+    ungated = redact_text(text)
+
+    assert gated == ungated
+
+
+def test_line_gate_selects_every_known_secret():
+    """No line carrying a known-format secret may be skipped by the gate."""
+    for secret in _KNOWN_FORMAT:
+        for line in (secret, f"key = {secret}", f"`{secret}`", f"see url/{secret}?x=1"):
+            assert redact_mod._LINE_NEEDS_SCAN.search(line) is not None, line
+    # A long pure-lowercase run (valid base64, entropy can exceed the 4.5 limit)
+    # must still be selected via the second alternative.
+    assert redact_mod._LINE_NEEDS_SCAN.search("a" * (redact_mod._PROSE_MAX_LEN + 1)) is not None
+    # Pure short lowercase prose is the only thing allowed to be skipped.
+    assert redact_mod._LINE_NEEDS_SCAN.search("this skill deploys your app") is None
+
+
 def test_prefilter_skips_only_safe_tokens():
     """Spot-check the gate's contract on boundary cases."""
     # skipped (pure lowercase, <=22)

--- a/tests/unit/test_redact_prefilter_equivalence.py
+++ b/tests/unit/test_redact_prefilter_equivalence.py
@@ -92,47 +92,6 @@ def test_prefilter_output_identical_to_unfiltered(seed, monkeypatch):
     assert gated == ungated
 
 
-class _AlwaysMatch:
-    """Stand-in for ``_LINE_NEEDS_SCAN`` that forces every line through the full scan."""
-
-    @staticmethod
-    def search(_line):
-        return True
-
-
-@pytest.mark.parametrize("seed", [1, 7, 42, 20260618, 999999])
-def test_line_gate_output_identical_to_unfiltered(seed, monkeypatch):
-    """The line-level gate (_LINE_NEEDS_SCAN) must skip only lines the full scan
-    would leave unchanged: gate-on output == gate-off output, byte-for-byte."""
-    rng = random.Random(seed)
-    tokens = _build_tokens(rng, 4000)
-    lines, i = [], 0
-    while i < len(tokens):
-        width = rng.randint(1, 12)
-        lines.append(" ".join(tokens[i : i + width]))
-        i += width
-    text = "\n".join(lines)
-
-    gated = redact_text(text)  # real _LINE_NEEDS_SCAN
-
-    monkeypatch.setattr(redact_mod, "_LINE_NEEDS_SCAN", _AlwaysMatch)  # disable line gate
-    ungated = redact_text(text)
-
-    assert gated == ungated
-
-
-def test_line_gate_selects_every_known_secret():
-    """No line carrying a known-format secret may be skipped by the gate."""
-    for secret in _KNOWN_FORMAT:
-        for line in (secret, f"key = {secret}", f"`{secret}`", f"see url/{secret}?x=1"):
-            assert redact_mod._LINE_NEEDS_SCAN.search(line) is not None, line
-    # A long pure-lowercase run (valid base64, entropy can exceed the 4.5 limit)
-    # must still be selected via the second alternative.
-    assert redact_mod._LINE_NEEDS_SCAN.search("a" * (redact_mod._PROSE_MAX_LEN + 1)) is not None
-    # Pure short lowercase prose is the only thing allowed to be skipped.
-    assert redact_mod._LINE_NEEDS_SCAN.search("this skill deploys your app") is None
-
-
 def test_prefilter_skips_only_safe_tokens():
     """Spot-check the gate's contract on boundary cases."""
     # skipped (pure lowercase, <=22)

--- a/tests/unit/test_skill_client.py
+++ b/tests/unit/test_skill_client.py
@@ -264,7 +264,11 @@ def _collect_skill_files_in_subprocess(skill_path: Path) -> subprocess.Completed
         ],
         capture_output=True,
         text=True,
-        timeout=2,
+        # Guards against a real hang (symlink cycle / blocking FIFO open), not a
+        # perf budget: the child cold-starts a fresh interpreter and imports
+        # detect_secrets, which can take >2s on a loaded CI runner. Kept well
+        # above that import cost so a genuine hang still fails fast.
+        timeout=10,
         check=False,
     )
 


### PR DESCRIPTION
Secret redaction of skill file contents dominated `agent-scan scan` CPU: detect-secrets ran its full plugin battery per whitespace token, and free text repeats the same tokens heavily (e.g. `the` ~14k times per run). ~90% of the ~468k per-token detections were duplicates.

- Add `_detect_secret_cached`, an `lru_cache`-memoized, value-keyed wrapper over `_detect_secret_in_plugins`. Detection is a pure function of the token and the process-wide plugin set, so memoizing by value is exact, not heuristic. Collapses ~468k detections to ~49k (distinct tokens).
- Add `_LINE_NEEDS_SCAN`, a one-regex line-level gate that skips the whole token battery for pure lowercase-ASCII prose lines (the line-level lift of `_could_be_secret`); conservative, provably skips only non-matching lines.
- Add fuzz/equivalence tests proving the line gate never skips a line the full scan would redact, and never gates out a known secret.
**Before**: 
`_redact_secrets_in_line` called `_detect_secret(candidate, plugins)` per token, with no memory:
line "use the MCP server the tool"  -> tokens: use, the, MCP, server, the, tool
  "the" appears here (and ~14,000 times across all skill files)
  -> EVERY occurrence ran the full ~12-plugin battery (regex findall + Shannon entropy)

**After**:
it calls `_detect_secret_cached(candidate)`:
first time "the" is seen  -> cache miss -> run the plugin battery once -> store {"the": None}
every later "the"         -> cache hit  -> return None via a dict lookup (no detect_secrets work)

Measured on macOS (arm64 binary, `scan` mode, user CPU, median of 3): before 5.88s -> after 2.32s (-61%, 2.5x). Output is byte-identical.