### PR TITLE
fix(ADS-678): name the enterprise quota in the 429 message

### DIFF
--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -544,7 +544,18 @@ async def analyze_machine(
             elif e.status == 413:
                 error_text = "Analysis scope too large (e.g. too many or very large MCP servers/skills). Please consider scanning individual MCP servers or skill directories."
             elif e.status == 429:
-                error_text = "Daily usage limit reached for the public version of Agent-Scan. Unlock higher limits and enterprise features by contacting us at https://evo.ai.snyk.io/#contact-us."
+                # A push key puts the scan on the enterprise budget, everything else
+                # on the public one. The two exhaust for different reasons and have
+                # different remedies, so telling an enterprise caller to buy
+                # enterprise sends them looking in the wrong place.
+                error_text = (
+                    "Daily usage limit reached for the enterprise version of Agent-Scan. "
+                    "Please contact support to increase your quota."
+                    if push_key
+                    else "Daily usage limit reached for the public version of Agent-Scan. "
+                    "Unlock higher limits and enterprise features by contacting us at "
+                    "https://evo.ai.snyk.io/#contact-us."
+                )
             elif 400 <= e.status < 500:
                 error_text = f"The analysis server returned an error for your request: {e.status} - {e.message}"
             else:

--- a/tests/unit/test_verify_api.py
+++ b/tests/unit/test_verify_api.py
@@ -866,6 +866,53 @@ class TestAnalyzeMachineHttpErrors:
             assert path.server_risks == []
             assert path.skill_risks == []
 
+    @pytest.mark.asyncio
+    async def test_429_with_push_key_names_the_enterprise_quota(self):
+        """A push key is on the enterprise budget, so the public-tier upsell would misdirect."""
+        inspected_paths = self._make_inspected_paths()
+        analysis_url = "https://test.example.com/api"
+
+        with patch("agent_scan.verify_api.aiohttp.ClientSession") as mock_session_class:
+            mock_session = MagicMock()
+
+            mock_request_info = MagicMock()
+            mock_request_info.real_url = analysis_url
+
+            error = aiohttp.ClientResponseError(
+                request_info=mock_request_info,
+                history=(),
+                status=429,
+                message="Too Many Requests",
+            )
+
+            mock_response = AsyncMock()
+            mock_response.status = 429
+            mock_response.raise_for_status = MagicMock(side_effect=error)
+
+            mock_post = MagicMock()
+            mock_post.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_post.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session.post = MagicMock(return_value=mock_post)
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+
+            mock_session_class.return_value = mock_session
+
+            result = await analyze_machine(
+                inspected_paths=inspected_paths,
+                analysis_url=analysis_url,
+                identifier=None,
+                push_key="test-push-key",
+                show_analysis_results=True,
+                max_retries=1,
+            )
+
+        for path in result.scan_path_responses:
+            assert path.error is not None
+            assert "Daily usage limit reached for the enterprise version of Agent-Scan" in path.error.message
+            assert "public version" not in path.error.message
+
 
 def _make_get_session(*, status, json_data=None, get_exc=None):
     """A mock ClientSession whose ``.get(...)`` yields a response with the given status/json."""


### PR DESCRIPTION
## Why

The 429 handler in `verify_api.py` hardcoded a single message for every rate-limit response:

> Daily usage limit reached for the **public version** of Agent-Scan. Unlock higher limits and enterprise features by contacting us at ...

So an enterprise push-key caller who exhausts the *enterprise* budget is told they are on the public tier and should contact sales for enterprise features. That happened on PC01 this morning: `cost.24h` for `budget:enterprise` hit $530.86 against a $500/day cap, and the message pointed the investigation at auth and routing instead of at spend.

## How

A push key routes the scan to `/hidden/mcp-scan/analysis-machine`, which the backend hardcodes to `budget=ENTERPRISE`; everything else goes to the CLI route and `get_budget_for_user`, which yields the public tier. The caller therefore already knows which budget applies, with no need to parse the response body:

```python
elif e.status == 429:
    error_text = (
        "Daily usage limit reached for the enterprise version of Agent-Scan. "
        "Please contact support to increase your quota."
        if push_key
        else "Daily usage limit reached for the public version of Agent-Scan. ..."
    )
```

The remedy sentence mirrors the backend's own 429 detail for that bucket ("Please contact support to increase your quota"), so the CLI and API now say the same thing.

## Tests

Adds `test_429_with_push_key_names_the_enterprise_quota`, asserting the enterprise wording and that "public version" is absent. The existing parametrized 429 case runs without a push key, so it still covers the public path unchanged.

`ruff`, `ruff-format` and `mypy` pass on both files. `tests/unit/test_verify_api.py` goes from 85 to 86 passing, with the same 8 pre-existing failures before and after.

## Follow-up worth considering

Keying off `push_key` is accurate for the two real cases but does not cover `internal_tier`, which the backend can also return for internal principals. Reading the backend's 429 `detail` would be exact, but `raise_for_status()` discards the body, so it needs a small refactor of the error path.

Made with [Cursor](https://cursor.com)