### PR TITLE
fix: add temporary discovery install fallbacks

### DIFF
--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -213,11 +213,16 @@ def _run_install(args) -> None:
     if not tenant_id:
         tenant_id = (os.environ.get("TENANT_ID", "") or "").strip()
     managed: bool = getattr(args, "managed", False)
-    # for the release i'll create a new PR to add hostname as default for machine_id but i'll make it separate to be clear. machine_id needs to be mandatory if we want to reliably identify the servers
     machine_id = (getattr(args, "machine_id", None) or os.environ.get("MACHINE_ID", "") or "").strip()
     if not machine_id:
-        rich.print("[bold red]Error:[/bold red] --machine-id is required (or set the MACHINE_ID environment variable).")
-        sys.exit(1)
+        # Temporary compatibility fallback until ADS Installer supplies MACHINE_ID.
+        from agent_scan.utils import get_hostname
+
+        machine_id = get_hostname()
+        rich.print(
+            "[yellow]Warning:[/yellow] MACHINE_ID is not set; temporarily using the hostname. "
+            "MACHINE_ID will become mandatory once ADS Installer is updated."
+        )
 
     clients = ALL_CLIENTS if client == "all" else [client]
 
@@ -506,9 +511,15 @@ def _install_hooks(
     old_push_key = existing_info.get("auth_value", "") if existing_info else ""
     push_key_changed = bool(old_push_key) and old_push_key != push_key
 
+    configured_agent_scan_command = os.environ.get("AGENT_SCAN_COMMAND", "").strip()
     agent_scan_command = _agent_scan_command()
     install_discovery = agent_scan_command is not None
-    if agent_scan_command is None:
+    if not configured_agent_scan_command and agent_scan_command is not None:
+        rich.print(
+            "[yellow]Warning:[/yellow] AGENT_SCAN_COMMAND is not set; temporarily using the current "
+            "Agent Scan executable. AGENT_SCAN_COMMAND will become mandatory once ADS Installer is updated."
+        )
+    elif agent_scan_command is None:
         rich.print(
             "[yellow]Warning:[/yellow] AGENT_SCAN_COMMAND is not set; "
             "the session-start discovery hook will not be installed"
@@ -1659,8 +1670,20 @@ def _build_hook_command(
 
 
 def _agent_scan_command() -> str | None:
-    """The configured command the session-start hook should invoke, if any."""
-    return os.environ.get("AGENT_SCAN_COMMAND", "").strip() or None
+    """Return the configured command or infer this Agent Scan executable."""
+    configured = os.environ.get("AGENT_SCAN_COMMAND", "").strip()
+    if configured:
+        return configured
+
+    # Temporary compatibility fallback until ADS Installer supplies AGENT_SCAN_COMMAND.
+    if getattr(sys, "frozen", False):
+        return str(Path(sys.executable).absolute())
+
+    executable_name = "snyk-agent-scan.exe" if IS_WINDOWS else "snyk-agent-scan"
+    console_script = Path(sys.executable).parent / executable_name
+    if console_script.is_file() and os.access(console_script, os.X_OK):
+        return str(console_script.absolute())
+    return None
 
 
 def _build_discover_hook_command(

--- a/tests/e2e/test_guard_install.py
+++ b/tests/e2e/test_guard_install.py
@@ -53,8 +53,11 @@ class TestGuardInstallE2E:
     """
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
-    def test_guard_install_claude(self, agent_scan_cmd, agent_scan_command, tmp_path, fake_hook_server):
+    def test_guard_install_claude(self, agent_scan_cmd, tmp_path, fake_hook_server):
         config_file = tmp_path / "settings.json"
+        install_env = {**os.environ, "PUSH_KEY": "test-pk-e2e"}
+        install_env.pop("AGENT_SCAN_COMMAND", None)
+        install_env.pop("MACHINE_ID", None)
         result = subprocess.run(
             [
                 *agent_scan_cmd,
@@ -65,13 +68,11 @@ class TestGuardInstallE2E:
                 str(config_file),
                 "--url",
                 fake_hook_server,
-                "--machine-id",
-                "e2e-machine-id",
             ],
             capture_output=True,
             text=True,
             timeout=60,
-            env={**os.environ, "PUSH_KEY": "test-pk-e2e", "AGENT_SCAN_COMMAND": str(agent_scan_command)},
+            env=install_env,
         )
         assert result.returncode == 0, f"guard install failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
 
@@ -100,7 +101,8 @@ class TestGuardInstallE2E:
         assert isinstance(discovered["body"]["servers"], list)
         assert isinstance(discovered["body"]["discovery_duration_ms"], int)
         assert discovered["body"]["discovery_duration_ms"] >= 0
-        assert json.loads(discovered["headers"]["X-User"])["identifier"] == "e2e-machine-id"
+        discovered_user = json.loads(discovered["headers"]["X-User"])
+        assert discovered_user["identifier"] == discovered_user["hostname"]
 
         discover_result = subprocess.run(
             [*agent_scan_cmd, "guard", "discover", "--client", "claude-code"],

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -379,19 +379,66 @@ class TestBuildHookCommand:
 class TestAgentScanCommand:
     def test_uses_environment_value(self, monkeypatch):
         monkeypatch.setenv("AGENT_SCAN_COMMAND", "cd /repo; uv run -m src.agent_scan.cli")
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
 
         assert guard_module._agent_scan_command() == "cd /repo; uv run -m src.agent_scan.cli"
 
-    def test_returns_none_when_environment_unset(self, monkeypatch):
+    def test_frozen_runtime_uses_absolute_current_executable(self, tmp_path, monkeypatch):
         monkeypatch.delenv("AGENT_SCAN_COMMAND", raising=False)
+        executable = tmp_path / "dist" / "snyk-agent-scan"
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(executable))
 
-        assert guard_module._agent_scan_command() is None
+        assert guard_module._agent_scan_command() == str(executable.absolute())
 
     @pytest.mark.parametrize("value", ["", "   "])
-    def test_returns_none_when_environment_value_is_blank(self, monkeypatch, value):
+    def test_blank_environment_value_uses_runtime_fallback(self, tmp_path, monkeypatch, value):
         monkeypatch.setenv("AGENT_SCAN_COMMAND", value)
+        executable = tmp_path / "dist" / "snyk-agent-scan"
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "executable", str(executable))
 
-        assert guard_module._agent_scan_command() is None
+        assert guard_module._agent_scan_command() == str(executable.absolute())
+
+    def test_uv_runtime_uses_sibling_console_script(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENT_SCAN_COMMAND", raising=False)
+        bin_dir = tmp_path / ".venv" / "bin"
+        bin_dir.mkdir(parents=True)
+        console_script = bin_dir / "snyk-agent-scan"
+        console_script.write_text("#!/bin/sh\n")
+        console_script.chmod(0o755)
+        monkeypatch.setattr(sys, "frozen", False, raising=False)
+        monkeypatch.setattr(sys, "executable", str(bin_dir / "python"))
+
+        with patch(f"{_G}.IS_WINDOWS", False):
+            command = guard_module._agent_scan_command()
+
+        assert command == str(console_script.absolute())
+
+    def test_windows_uv_runtime_uses_sibling_console_executable(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENT_SCAN_COMMAND", raising=False)
+        scripts_dir = tmp_path / ".venv" / "Scripts"
+        scripts_dir.mkdir(parents=True)
+        console_script = scripts_dir / "snyk-agent-scan.exe"
+        console_script.write_text("binary")
+        console_script.chmod(0o755)
+        monkeypatch.setattr(sys, "frozen", False, raising=False)
+        monkeypatch.setattr(sys, "executable", str(scripts_dir / "python.exe"))
+
+        with patch(f"{_G}.IS_WINDOWS", True):
+            command = guard_module._agent_scan_command()
+
+        assert command == str(console_script.absolute())
+
+    def test_returns_none_when_runtime_cannot_be_resolved(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AGENT_SCAN_COMMAND", raising=False)
+        monkeypatch.setattr(sys, "frozen", False, raising=False)
+        monkeypatch.setattr(sys, "executable", str(tmp_path / "bin" / "python"))
+
+        with patch(f"{_G}.IS_WINDOWS", False):
+            command = guard_module._agent_scan_command()
+
+        assert command is None
 
 
 class TestBuildDiscoverHookCommand:
@@ -3721,6 +3768,14 @@ class TestInstallHooksOrchestration:
         ]
         assert ctx["prep_codex_managed"].call_args.kwargs["discover_command"] == "discover-cmd"
 
+    def test_inferred_agent_scan_command_warns_that_fallback_is_temporary(self, ctx, tmp_path):
+        self._call(tmp_path, client="claude")
+
+        assert any(
+            "AGENT_SCAN_COMMAND will become mandatory once ADS Installer is updated" in message
+            for message in self._print_messages(ctx)
+        )
+
     def test_unset_agent_scan_command_skips_discovery_without_aborting(self, ctx, tmp_path):
         ctx["agent_scan_command"].return_value = None
 
@@ -5274,19 +5329,30 @@ class TestRunInstallSendsServersDiscovered:
         assert install.call_args.args[-1] == expected
         assert send.call_args.args[-1] == expected
 
-    def test_missing_machine_id_aborts_before_install(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("arg_machine_id, env_machine_id", [(None, None), ("   ", "   ")])
+    def test_missing_machine_id_uses_hostname_for_install_and_send(
+        self, tmp_path, monkeypatch, arg_machine_id, env_machine_id
+    ):
         monkeypatch.setenv("PUSH_KEY", "headless-pk")
-        monkeypatch.delenv("MACHINE_ID", raising=False)
+        if env_machine_id is None:
+            monkeypatch.delenv("MACHINE_ID", raising=False)
+        else:
+            monkeypatch.setenv("MACHINE_ID", env_machine_id)
         with (
-            patch(f"{_G}._install_hooks") as install,
-            patch(f"{_G}._send_servers_discovered_event") as send,
-            pytest.raises(SystemExit) as exc,
+            patch("agent_scan.utils.get_hostname", return_value="fallback-host"),
+            patch(f"{_G}._install_hooks", return_value=Path("/installed/hook.sh")) as install,
+            patch(f"{_G}._send_servers_discovered_event", return_value=True) as send,
+            patch(f"{_G}.rich") as rich_mock,
         ):
-            _run_install(self._args(tmp_path, machine_id=None))
+            _run_install(self._args(tmp_path, machine_id=arg_machine_id))
 
-        assert exc.value.code == 1
-        install.assert_not_called()
-        send.assert_not_called()
+        assert install.call_args.args[-1] == "fallback-host"
+        assert send.call_args.args[-1] == "fallback-host"
+        assert any(
+            "MACHINE_ID will become mandatory once ADS Installer is updated" in call.args[0]
+            for call in rich_mock.print.call_args_list
+            if call.args
+        )
 
     def test_managed_install_sends(self, tmp_path, monkeypatch):
         monkeypatch.setenv("PUSH_KEY", "headless-pk")


### PR DESCRIPTION
## Summary

- temporarily fall back to hostname when machine identity is missing during hook installation
- infer the Agent Scan executable for PyInstaller and uv runtimes when AGENT_SCAN_COMMAND is missing
- warn that both values will become mandatory after ADS Installer is updated

## Test plan

- .venv/bin/pytest -q tests/unit/test_guard.py
- .venv/bin/pytest -q tests/e2e/test_guard_install.py tests/unit/test_cli_parsing.py
- pre-commit run --all-files