### PR TITLE
chore: increase timeout for sync API calls

### DIFF
--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -531,7 +531,7 @@ async def analyze_machine(
                     analysis_url,
                     data=payload.model_dump_json(),
                     headers=headers,
-                    timeout=aiohttp.ClientTimeout(total=75),
+                    timeout=aiohttp.ClientTimeout(total=180),
                 ) as response:
                     response.raise_for_status()
                     if response.status == 200:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single timeout constant change on the sync analysis client; no auth or payload logic changes, though longer waits may delay failure/retry behavior on truly stuck requests.
> 
> **Overview**
> Raises the **total HTTP timeout** for synchronous machine analysis POSTs in `analyze_machine` from **75s to 180s**, so slow backend analysis is less likely to fail with `TimeoutError` before retries exhaust.
> 
> Async submission (`_submit_async_analysis`) still uses a 75s timeout; only the sync path that waits for `ScanResponse` is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b96a79e996255cf70f8fc245b4aecc345f0eac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->