### PR TITLE
feat: add discovery scope filtering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      # The mypy hook runs in the project environment (see .pre-commit-config.yaml),
+      # so it needs uv the same way the test job does.
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
       - uses: pre-commit/action@v3.0.1
   test:
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,18 @@
 repos:
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.15.0'  # Use the sha / tag you want to point at
+- repo: local
   hooks:
+  # Runs in the project environment rather than mirrors-mypy's isolated one.
+  # That hook only installed types-requests and types-PyYAML, so with
+  # ignore_missing_imports pydantic's BaseModel degraded to Any and every
+  # pydantic-derived error disappeared -- it reported success on a tree with 40
+  # real errors. Passing the package instead of the changed files keeps
+  # cross-module inference intact.
   - id: mypy
-    args: [--config-file=pyproject.toml]
-    additional_dependencies: [types-requests, types-PyYAML]
-    exclude: ^tests/skills/
+    name: mypy
+    entry: uv run --with mypy mypy --config-file=pyproject.toml src/agent_scan/
+    language: system
+    types: [python]
+    pass_filenames: false
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.11.8

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ The four scopes:
 - **Project / workspace** — config scoped to an opened project or workspace.
 - **Extension / plugin** — components bundled inside installed extensions or plugins.
 
+Their machine-readable values are `system`, `user`, `project_workspace`, and `extension_plugin`. Explicit positional
+inputs are tracked internally as `custom`; they are caller-selected rather than part of automatic discovery.
+
 Legend: **✓** detected · **✗** the agent supports this but Agent Scan does not scan it yet · **N/A** the agent has no such component at this scope.
 
 | Agent | System<br>skills | System<br>servers | User<br>skills | User<br>servers | Project / WS<br>skills | Project / WS<br>servers | Ext / plugin<br>skills | Ext / plugin<br>servers |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -357,6 +357,8 @@ snyk-agent-scan guard install {claude,cursor,codex,all} [OPTIONS]
 
 After configuring the hooks, installation sends a `hooksConfiguredServerDiscovery` event. It also configures a
 fire-and-forget session-start hook that reports discovered MCP servers with a `sessionStartServerDiscovery` event.
+Session-start discovery excludes the current project/workspace scope and reports system, user, and installed
+extension/plugin components.
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -382,6 +384,7 @@ folder(s) from the selected client's hook payload, discovers MCP servers locally
 | `--url URL` | string | `https://api.snyk.io` | Remote hook base URL for the Snyk API environment. |
 | `--client {claude-code,cursor,codex}` | string | required | Hook client whose target-folder payload and endpoint conventions should be used. |
 | `--scope {servers,skills,all}` | string | `all` | Discovery data to collect. The session-start hook installed by `guard install` passes `servers`, because the event it sends carries MCP servers only. |
+| `--skip-discovery-scopes CSV` | CSV | none | Exclude `system`, `user`, `project_workspace`, or `extension_plugin`. Use `all` to exclude every automatic scope. Generated SessionStart hooks pass `project_workspace`. |
 
 ### `guard uninstall`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -384,7 +384,7 @@ folder(s) from the selected client's hook payload, discovers MCP servers locally
 | `--url URL` | string | `https://api.snyk.io` | Remote hook base URL for the Snyk API environment. |
 | `--client {claude-code,cursor,codex}` | string | required | Hook client whose target-folder payload and endpoint conventions should be used. |
 | `--scope {servers,skills,all}` | string | `all` | Discovery data to collect. The session-start hook installed by `guard install` passes `servers`, because the event it sends carries MCP servers only. |
-| `--skip-discovery-scopes CSV` | CSV | none | Exclude `system`, `user`, `project_workspace`, or `extension_plugin`. Use `all` to exclude every automatic scope. Generated SessionStart hooks pass `project_workspace`. |
+| `--skip-discovery-scopes CSV` | CSV | none | Exclude `system`, `user`, `project_workspace`, or `extension_plugin`; accepts a comma-separated list. An excluded scope is dropped per component, so a config file holding more than one scope (`~/.claude.json`) keeps the parts still in scope, and a detected agent is still reported with whatever remains. Use `all` to exclude every automatic scope, which reports nothing at all -- not even which agents are installed. Generated SessionStart hooks pass `project_workspace`. |
 
 ### `guard uninstall`
 

--- a/src/agent_scan/agents/__init__.py
+++ b/src/agent_scan/agents/__init__.py
@@ -21,6 +21,7 @@ from agent_scan.agents.vscode import (
     VSCodeFamilyDiscoverer,
     WindsurfDiscoverer,
 )
+from agent_scan.models import AUTOMATIC_DISCOVERY_SCOPES, DiscoveryLocationScope
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,11 @@ DISCOVERERS: dict[str, type[AgentDiscoverer]] = {
 }
 
 
-def find_discoverers(home_directory: Path | None, target_folders: list[Path] | None = None) -> list[AgentDiscoverer]:
+def find_discoverers(
+    home_directory: Path | None,
+    target_folders: list[Path] | None = None,
+    skip_discovery_scopes: set[DiscoveryLocationScope] | frozenset[DiscoveryLocationScope] | None = None,
+) -> list[AgentDiscoverer]:
     """Construct one instance per registered discoverer with the given home and
     explicit request targets, then return only those whose ``client_exists()``
     confirms the agent is installed. Each returned instance is home-bound; the
@@ -46,9 +51,12 @@ def find_discoverers(home_directory: Path | None, target_folders: list[Path] | N
     A discoverer whose ``client_exists()`` raises is skipped (and logged) so a
     single buggy subclass cannot abort discovery for the whole machine.
     """
+    skipped = frozenset(skip_discovery_scopes or ())
+    if skipped >= AUTOMATIC_DISCOVERY_SCOPES:
+        return []
     found: list[AgentDiscoverer] = []
     for cls in DISCOVERERS.values():
-        discoverer = cls(home_directory, target_folders)
+        discoverer = cls(home_directory, target_folders, skipped)
         try:
             exists = discoverer.client_exists() is not None
         except Exception:

--- a/src/agent_scan/agents/__init__.py
+++ b/src/agent_scan/agents/__init__.py
@@ -48,19 +48,33 @@ def find_discoverers(
     confirms the agent is installed. Each returned instance is home-bound; the
     caller just runs ``d.discover()`` on each.
 
-    A discoverer whose ``client_exists()`` raises is skipped (and logged) so a
-    single buggy subclass cannot abort discovery for the whole machine.
+    A discoverer whose construction or ``client_exists()`` raises is skipped
+    (and logged) so a single buggy subclass cannot abort discovery for the whole
+    machine. Construction is inside the guard because ``AgentDiscoverer``
+    coerces the scope set and raises on an unrecognized value -- and it would
+    raise on the *first* registered discoverer, taking out all of them.
     """
-    skipped = frozenset(skip_discovery_scopes or ())
+    # Coerced here, not just in the constructor: a str-Enum member hashes equal
+    # to its value, so a set of bare strings would sail through the
+    # ``>=`` check below and only blow up per discoverer. A bare string is
+    # accepted too, since ``frozenset("user")`` would otherwise iterate
+    # characters.
+    if isinstance(skip_discovery_scopes, str):
+        skip_discovery_scopes = {skip_discovery_scopes}  # type: ignore[assignment]
+    try:
+        skipped = frozenset(DiscoveryLocationScope(scope) for scope in skip_discovery_scopes or ())
+    except ValueError:
+        logger.exception("Unrecognized discovery location scope; discovering nothing")
+        return []
     if skipped >= AUTOMATIC_DISCOVERY_SCOPES:
         return []
     found: list[AgentDiscoverer] = []
     for cls in DISCOVERERS.values():
-        discoverer = cls(home_directory, target_folders, skipped)
         try:
+            discoverer = cls(home_directory, target_folders, skipped)
             exists = discoverer.client_exists() is not None
         except Exception:
-            logger.exception("Discoverer %s.client_exists() raised; skipping", cls.__name__)
+            logger.exception("Discoverer %s failed to construct or probe; skipping", cls.__name__)
             continue
         if exists:
             found.append(discoverer)

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -273,7 +273,7 @@ class AgentDiscoverer(ABC):
             if not isinstance(value, list):
                 scoped[path] = value
                 continue
-            entries: list[DiscoveredServer] = []
+            entries: list[DiscoveredServer | tuple[str, StdioServer | RemoteServer]] = []
             for entry in value:
                 if isinstance(entry, DiscoveredServer):
                     entry_scope = scope if entry.scope is DiscoveryLocationScope.CUSTOM else entry.scope

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -22,7 +22,9 @@ from agent_scan.models import (
     SERVER_CONFIG_DISCRIMINATOR_KEYS,
     ClientToInspect,
     CouldNotParseMCPConfig,
+    DiscoveredServer,
     DiscoveredSkill,
+    DiscoveryLocationScope,
     FileNotFoundConfig,
     MCPConfig,
     MCPServerMap,
@@ -36,7 +38,10 @@ from agent_scan.skill_client import inspect_skills_dir
 logger = logging.getLogger(__name__)
 McpConfigsResult = dict[
     str,
-    list[tuple[str, StdioServer | RemoteServer]] | FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig,
+    list[DiscoveredServer | tuple[str, StdioServer | RemoteServer]]
+    | FileNotFoundConfig
+    | UnknownConfigFormat
+    | CouldNotParseMCPConfig,
 ]
 SkillsDirsResult = dict[str, list[DiscoveredSkill] | FileNotFoundConfig]
 # Return type of the per-file MCP parsers (``_parse_mcp_file`` /
@@ -49,6 +54,15 @@ class DiscoveryScope(str, Enum):
     SERVERS = "servers"
     SKILLS = "skills"
     ALL = "all"
+
+
+_LOCATION_SCOPE_PRECEDENCE = {
+    DiscoveryLocationScope.PROJECT_WORKSPACE: 0,
+    DiscoveryLocationScope.USER: 1,
+    DiscoveryLocationScope.EXTENSION_PLUGIN: 2,
+    DiscoveryLocationScope.SYSTEM: 3,
+    DiscoveryLocationScope.CUSTOM: 4,
+}
 
 
 # Cap traversal into ``~/.claude/plugins/{cache,repos}``
@@ -153,13 +167,19 @@ class AgentDiscoverer(ABC):
 
     name: str = ""
 
-    def __init__(self, home_directory: Path | None, target_folders: list[Path] | None = None) -> None:
+    def __init__(
+        self,
+        home_directory: Path | None,
+        target_folders: list[Path] | None = None,
+        skip_discovery_scopes: set[DiscoveryLocationScope] | frozenset[DiscoveryLocationScope] | None = None,
+    ) -> None:
         # ``None`` is the own-home sentinel; normalize to ``Path.home()`` so the
         # stored home is always concrete. ``expand_path`` treats ``None`` as
         # "unknown home — don't expand", which would leave a ``~``-prefixed literal
         # (e.g. ``~/.claude``) on an own-home scan whose relocating env var is unset.
         self.home_directory = home_directory if home_directory is not None else Path.home()
         self.target_folders = list(target_folders or [])
+        self.skip_discovery_scopes = frozenset(DiscoveryLocationScope(scope) for scope in skip_discovery_scopes or ())
         # Lazily-populated cache of the discovery roots (recorded project roots plus
         # explicit target roots) with their ancestors. A discoverer serves a single
         # scan (see find_discoverers), so the list is stable for its lifetime and
@@ -242,6 +262,82 @@ class AgentDiscoverer(ABC):
             mcp_configs=mcp_configs,
             skills_dirs=skills_dirs,
         )
+
+    def _scope_enabled(self, scope: DiscoveryLocationScope) -> bool:
+        return scope not in self.skip_discovery_scopes
+
+    @staticmethod
+    def _scope_mcp_results(results: McpConfigsResult, scope: DiscoveryLocationScope) -> McpConfigsResult:
+        scoped: McpConfigsResult = {}
+        for path, value in results.items():
+            if not isinstance(value, list):
+                scoped[path] = value
+                continue
+            entries: list[DiscoveredServer] = []
+            for entry in value:
+                if isinstance(entry, DiscoveredServer):
+                    entry_scope = scope if entry.scope is DiscoveryLocationScope.CUSTOM else entry.scope
+                    entries.append(entry.model_copy(update={"scope": entry_scope}))
+                else:
+                    name, server = entry
+                    entries.append(DiscoveredServer(name=name, server=server, scope=scope))
+            scoped[path] = entries
+        return scoped
+
+    @staticmethod
+    def _scope_skill_results(results: SkillsDirsResult, scope: DiscoveryLocationScope) -> SkillsDirsResult:
+        scoped: SkillsDirsResult = {}
+        for path, value in results.items():
+            if not isinstance(value, list):
+                scoped[path] = value
+                continue
+            scoped[path] = [
+                skill.model_copy(
+                    update={"scope": scope if skill.scope is DiscoveryLocationScope.CUSTOM else skill.scope}
+                )
+                for skill in value
+            ]
+        return scoped
+
+    @staticmethod
+    def _result_precedence(value: object) -> int:
+        if isinstance(value, list) and value:
+            first = value[0]
+            if isinstance(first, DiscoveredServer | DiscoveredSkill):
+                return _LOCATION_SCOPE_PRECEDENCE[first.scope]
+        return -1
+
+    def _merge_mcp_results(
+        self,
+        target: McpConfigsResult,
+        source: Callable[[], McpConfigsResult],
+        scope: DiscoveryLocationScope,
+    ) -> None:
+        if not self._scope_enabled(scope):
+            return
+        scoped = self._scope_mcp_results(source(), scope)
+        for path, value in scoped.items():
+            existing = target.get(path)
+            if existing is None or self._result_precedence(value) >= self._result_precedence(existing):
+                target[path] = value
+
+    def _merge_skill_results(
+        self,
+        target: SkillsDirsResult,
+        source: Callable[[], SkillsDirsResult],
+        scope: DiscoveryLocationScope,
+    ) -> None:
+        if not self._scope_enabled(scope):
+            return
+        scoped = self._scope_skill_results(source(), scope)
+        self._merge_scoped_skill_results(target, scoped)
+
+    def _merge_scoped_skill_results(self, target: SkillsDirsResult, source: SkillsDirsResult) -> None:
+        """Merge skill results whose entries already carry their location scope."""
+        for path, value in source.items():
+            existing = target.get(path)
+            if existing is None or self._result_precedence(value) >= self._result_precedence(existing):
+                target[path] = value
 
     # --- shared helpers (inherited by every concrete subclass) ---
 

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pyjson5
 
 from agent_scan.models import (
+    LOCATION_SCOPE_PRECEDENCE,
     SERVER_CONFIG_DISCRIMINATOR_KEYS,
     ClientToInspect,
     CouldNotParseMCPConfig,
@@ -56,14 +57,13 @@ class DiscoveryScope(str, Enum):
     ALL = "all"
 
 
-_LOCATION_SCOPE_PRECEDENCE = {
-    DiscoveryLocationScope.PROJECT_WORKSPACE: 0,
-    DiscoveryLocationScope.USER: 1,
-    DiscoveryLocationScope.EXTENSION_PLUGIN: 2,
-    DiscoveryLocationScope.SYSTEM: 3,
-    DiscoveryLocationScope.CUSTOM: 4,
-}
-
+# Merge ranks below the real ``LOCATION_SCOPE_PRECEDENCE`` band (0..4), ordered
+# so that data beats errors, a surfaced failure beats a benign record, and
+# "found nothing" never displaces anything. See ``_result_precedence``.
+_PRECEDENCE_EMPTY = -4
+_PRECEDENCE_NON_FAILURE = -3
+_PRECEDENCE_FAILURE = -2
+_PRECEDENCE_UNLABELLED = -1
 
 # Cap traversal into ``~/.claude/plugins/{cache,repos}``
 _MAX_PLUGIN_RGLOB_DEPTH = 10
@@ -186,6 +186,7 @@ class AgentDiscoverer(ABC):
         # discovery does not need to re-walk workspaceStorage / re-read
         # ~/.claude.json each time.
         self._discovery_paths_cache: list[Path] | None = None
+        self._project_anchors_cache: list[Path] | None = None
 
     def _scans_own_home(self) -> bool:
         """True when this discoverer targets the scanning process's own user.
@@ -266,34 +267,99 @@ class AgentDiscoverer(ABC):
     def _scope_enabled(self, scope: DiscoveryLocationScope) -> bool:
         return scope not in self.skip_discovery_scopes
 
-    @staticmethod
-    def _scope_mcp_results(results: McpConfigsResult, scope: DiscoveryLocationScope) -> McpConfigsResult:
+    def _is_home_or_above(self, root: Path) -> bool:
+        try:
+            return self.home_directory.is_relative_to(root)
+        except (OSError, ValueError):
+            return False
+
+    def _project_anchors(self) -> list[Path]:
+        """Discovery roots that can legitimately confer ``PROJECT_WORKSPACE``.
+
+        ``_discovery_paths_with_ancestors`` deliberately walks to the filesystem
+        root so a monorepo root above an opened project still counts as project
+        config. The side effect is that the scanned home -- and ``/`` -- are
+        ancestors of every project beneath them, so without this filter every
+        user-scope directory also looks project-scoped and
+        ``--skip-discovery-scopes user`` stops excluding anything.
+        """
+        if self._project_anchors_cache is None:
+            self._project_anchors_cache = [
+                root for root in self._discovery_paths_with_ancestors() if not self._is_home_or_above(root)
+            ]
+        return self._project_anchors_cache
+
+    def _location_scope_for(
+        self, path: Path, default: DiscoveryLocationScope = DiscoveryLocationScope.USER
+    ) -> DiscoveryLocationScope:
+        """Classify where a relocatable file or directory actually lives.
+
+        For paths an environment variable or config setting may point anywhere,
+        a fixed label is wrong in both directions: a project-local target
+        survives an exclusion meant to drop it, and a relocated global one is
+        dropped by an exclusion that should not apply.
+        """
+        if any(Path(os.path.normpath(path)).is_relative_to(anchor) for anchor in self._project_anchors()):
+            return DiscoveryLocationScope.PROJECT_WORKSPACE
+        return default
+
+    def _resolve_entry_scope(self, path: str, declared: DiscoveryLocationScope) -> DiscoveryLocationScope:
+        """Demote a ``PROJECT_WORKSPACE`` label that does not resolve inside a project.
+
+        Scope describes where a component lives, not which file mentioned it, so
+        a path is only project-scoped when it actually sits inside an opened
+        project (or an ancestor of one that is not the home). Two things depend
+        on this: the project sweep re-finds the user directories through the
+        ancestor walk, and a config file gets to name paths outside its own tier
+        -- a repo-committed one could otherwise point at the user's home and pick
+        the label that excludes it.
+
+        Only ``PROJECT_WORKSPACE`` is validated; it is the one label a caller can
+        obtain for a location it does not own. Compared lexically, with no
+        filesystem access, so a symlink planted between this check and the walk
+        cannot change the answer.
+        """
+        if declared is not DiscoveryLocationScope.PROJECT_WORKSPACE:
+            return declared
+        candidate = Path(os.path.normpath(path))
+        if any(candidate.is_relative_to(anchor) for anchor in self._project_anchors()):
+            return declared
+        return DiscoveryLocationScope.USER
+
+    def _scope_mcp_results(self, results: McpConfigsResult, scope: DiscoveryLocationScope) -> McpConfigsResult:
         scoped: McpConfigsResult = {}
         for path, value in results.items():
             if not isinstance(value, list):
                 scoped[path] = value
                 continue
+            path_scope = self._resolve_entry_scope(path, scope)
+            if not self._scope_enabled(path_scope):
+                # Demoted out of the requested set (e.g. a project sweep that
+                # re-found a user directory while user scope is excluded).
+                continue
             entries: list[DiscoveredServer | tuple[str, StdioServer | RemoteServer]] = []
             for entry in value:
                 if isinstance(entry, DiscoveredServer):
-                    entry_scope = scope if entry.scope is DiscoveryLocationScope.CUSTOM else entry.scope
+                    entry_scope = path_scope if entry.scope is DiscoveryLocationScope.CUSTOM else entry.scope
                     entries.append(entry.model_copy(update={"scope": entry_scope}))
                 else:
                     name, server = entry
-                    entries.append(DiscoveredServer(name=name, server=server, scope=scope))
+                    entries.append(DiscoveredServer(name=name, server=server, scope=path_scope))
             scoped[path] = entries
         return scoped
 
-    @staticmethod
-    def _scope_skill_results(results: SkillsDirsResult, scope: DiscoveryLocationScope) -> SkillsDirsResult:
+    def _scope_skill_results(self, results: SkillsDirsResult, scope: DiscoveryLocationScope) -> SkillsDirsResult:
         scoped: SkillsDirsResult = {}
         for path, value in results.items():
             if not isinstance(value, list):
                 scoped[path] = value
                 continue
+            path_scope = self._resolve_entry_scope(path, scope)
+            if not self._scope_enabled(path_scope):
+                continue
             scoped[path] = [
                 skill.model_copy(
-                    update={"scope": scope if skill.scope is DiscoveryLocationScope.CUSTOM else skill.scope}
+                    update={"scope": path_scope if skill.scope is DiscoveryLocationScope.CUSTOM else skill.scope}
                 )
                 for skill in value
             ]
@@ -301,11 +367,25 @@ class AgentDiscoverer(ABC):
 
     @staticmethod
     def _result_precedence(value: object) -> int:
-        if isinstance(value, list) and value:
+        """Rank a merge candidate for one path key. Higher wins.
+
+        Real data outranks every error record, and a deliberately-surfaced
+        failure outranks both "not present" and "found nothing" -- otherwise a
+        later pass that simply came up empty at the same path would erase a parse
+        error the scanner reports on purpose (opencode does exactly this for a
+        malformed ``$OPENCODE_CONFIG``).
+        """
+        if isinstance(value, list):
+            if not value:
+                return _PRECEDENCE_EMPTY
             first = value[0]
             if isinstance(first, DiscoveredServer | DiscoveredSkill):
-                return _LOCATION_SCOPE_PRECEDENCE[first.scope]
-        return -1
+                return LOCATION_SCOPE_PRECEDENCE[first.scope]
+            # A legacy ``(name, server)`` pair carries no scope; still real data.
+            return _PRECEDENCE_UNLABELLED
+        if getattr(value, "is_failure", False):
+            return _PRECEDENCE_FAILURE
+        return _PRECEDENCE_NON_FAILURE
 
     def _merge_mcp_results(
         self,

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -325,16 +325,20 @@ class AgentDiscoverer(ABC):
             return declared
         return DiscoveryLocationScope.USER
 
+    def _resolve_mcp_entry_scope(self, path: str, declared: DiscoveryLocationScope) -> DiscoveryLocationScope:
+        """Resolve MCP scope, allowing agents to recognize registered workspace files."""
+        return self._resolve_entry_scope(path, declared)
+
     def _scope_mcp_results(self, results: McpConfigsResult, scope: DiscoveryLocationScope) -> McpConfigsResult:
         scoped: McpConfigsResult = {}
         for path, value in results.items():
-            if not isinstance(value, list):
-                scoped[path] = value
-                continue
-            path_scope = self._resolve_entry_scope(path, scope)
+            path_scope = self._resolve_mcp_entry_scope(path, scope)
             if not self._scope_enabled(path_scope):
                 # Demoted out of the requested set (e.g. a project sweep that
                 # re-found a user directory while user scope is excluded).
+                continue
+            if not isinstance(value, list):
+                scoped[path] = value
                 continue
             entries: list[DiscoveredServer] = []
             for entry in value:
@@ -353,11 +357,11 @@ class AgentDiscoverer(ABC):
     def _scope_skill_results(self, results: SkillsDirsResult, scope: DiscoveryLocationScope) -> SkillsDirsResult:
         scoped: SkillsDirsResult = {}
         for path, value in results.items():
-            if not isinstance(value, list):
-                scoped[path] = value
-                continue
             path_scope = self._resolve_entry_scope(path, scope)
             if not self._scope_enabled(path_scope):
+                continue
+            if not isinstance(value, list):
+                scoped[path] = value
                 continue
             scoped[path] = [
                 skill.model_copy(

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -29,7 +29,6 @@ from agent_scan.models import (
     FileNotFoundConfig,
     MCPConfig,
     MCPServerMap,
-    RemoteServer,
     StdioServer,
     UnknownConfigFormat,
 )
@@ -39,16 +38,13 @@ from agent_scan.skill_client import inspect_skills_dir
 logger = logging.getLogger(__name__)
 McpConfigsResult = dict[
     str,
-    list[DiscoveredServer | tuple[str, StdioServer | RemoteServer]]
-    | FileNotFoundConfig
-    | UnknownConfigFormat
-    | CouldNotParseMCPConfig,
+    list[DiscoveredServer] | FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig,
 ]
 SkillsDirsResult = dict[str, list[DiscoveredSkill] | FileNotFoundConfig]
 # Return type of the per-file MCP parsers (``_parse_mcp_file`` /
 # ``_parse_settings_mcp_gated``): parsed servers, a parse failure, or ``None``
 # when the file is absent/empty/not-MCP.
-McpScanResult = list[tuple[str, StdioServer | RemoteServer]] | CouldNotParseMCPConfig | None
+McpScanResult = list[DiscoveredServer] | CouldNotParseMCPConfig | None
 
 
 class DiscoveryScope(str, Enum):
@@ -337,12 +333,15 @@ class AgentDiscoverer(ABC):
                 # Demoted out of the requested set (e.g. a project sweep that
                 # re-found a user directory while user scope is excluded).
                 continue
-            entries: list[DiscoveredServer | tuple[str, StdioServer | RemoteServer]] = []
+            entries: list[DiscoveredServer] = []
             for entry in value:
                 if isinstance(entry, DiscoveredServer):
                     entry_scope = path_scope if entry.scope is DiscoveryLocationScope.CUSTOM else entry.scope
                     entries.append(entry.model_copy(update={"scope": entry_scope}))
                 else:
+                    # Legacy ``(name, server)`` pair. Unreachable from the parsers,
+                    # which now emit ``DiscoveredServer`` directly, but kept because
+                    # tests inject sources in the historical shape.
                     name, server = entry
                     entries.append(DiscoveredServer(name=name, server=server, scope=path_scope))
             scoped[path] = entries
@@ -462,9 +461,13 @@ class AgentDiscoverer(ABC):
                 is_failure=True,
             )
 
-    def _servers_to_signed_list(self, validated: MCPConfig) -> list[tuple[str, StdioServer | RemoteServer]]:
-        """Materialize a validated config's servers into ``(name, server)`` tuples,
-        replacing each Stdio entry with its signature-checked form.
+    def _servers_to_signed_list(self, validated: MCPConfig) -> list[DiscoveredServer]:
+        """Materialize a validated config's servers, replacing each Stdio entry
+        with its signature-checked form.
+
+        Entries come back unlabelled (scope ``CUSTOM``, the not-yet-assigned
+        sentinel); ``_scope_mcp_results`` stamps the real scope when the source
+        is merged, so the parsers stay scope-agnostic.
 
         Shared by :meth:`_validate_servers` and :meth:`_parse_mcp_file` so the
         signature-check step stays in one place.
@@ -477,11 +480,9 @@ class AgentDiscoverer(ABC):
         for name, server_config in servers.items():
             if isinstance(server_config, StdioServer):
                 servers[name] = check_server_signature(server_config)
-        return list(servers.items())
+        return [DiscoveredServer(name=name, server=server) for name, server in servers.items()]
 
-    def _validate_servers(
-        self, raw: dict, source: str
-    ) -> list[tuple[str, StdioServer | RemoteServer]] | CouldNotParseMCPConfig:
+    def _validate_servers(self, raw: dict, source: str) -> list[DiscoveredServer] | CouldNotParseMCPConfig:
         """Validate a raw ``mcpServers`` mapping into typed Stdio/Remote server entries.
 
         Input is the *already-extracted* server map (e.g. the value of
@@ -505,7 +506,7 @@ class AgentDiscoverer(ABC):
         *,
         formats: tuple[type[MCPConfig], ...],
         skip_unrecognized: bool = False,
-    ) -> list[tuple[str, StdioServer | RemoteServer]] | CouldNotParseMCPConfig | None:
+    ) -> McpScanResult:
         """Load ``path``, try each ``MCPConfig`` subclass in order, return the first
         that validates.
 

--- a/src/agent_scan/agents/base.py
+++ b/src/agent_scan/agents/base.py
@@ -183,6 +183,9 @@ class AgentDiscoverer(ABC):
         # ~/.claude.json each time.
         self._discovery_paths_cache: list[Path] | None = None
         self._project_anchors_cache: list[Path] | None = None
+        # Populated by subclasses whose project enumeration is expensive
+        # (opencode reads a SQLite db); see OpenCodeDiscoverer._project_worktrees.
+        self._project_worktrees_cache: list[Path] | None = None
 
     def _scans_own_home(self) -> bool:
         """True when this discoverer targets the scanning process's own user.

--- a/src/agent_scan/agents/claude_code.py
+++ b/src/agent_scan/agents/claude_code.py
@@ -16,6 +16,7 @@ from agent_scan.agents.base import (
 from agent_scan.models import (
     ClaudeConfigFile,
     CouldNotParseMCPConfig,
+    DiscoveryLocationScope,
     MCPConfig,
     PluginMCPConfigFile,
 )
@@ -87,19 +88,23 @@ class ClaudeCodeDiscoverer(AgentDiscoverer):
 
     def discover_mcp_servers(self) -> McpConfigsResult:
         result: McpConfigsResult = {}
-        result.update(self._discover_global_mcp_servers())
-        result.update(self._discover_project_mcp_servers())
-        result.update(self._discover_plugin_mcp_servers())
-        result.update(self._discover_plugin_manifest_mcp_servers())
-        result.update(self._discover_managed_mcp_servers())
+        self._merge_mcp_results(result, self._discover_project_mcp_servers, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_mcp_results(result, self._discover_global_mcp_servers, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_plugin_mcp_servers, DiscoveryLocationScope.EXTENSION_PLUGIN)
+        self._merge_mcp_results(
+            result, self._discover_plugin_manifest_mcp_servers, DiscoveryLocationScope.EXTENSION_PLUGIN
+        )
+        self._merge_mcp_results(result, self._discover_managed_mcp_servers, DiscoveryLocationScope.SYSTEM)
         return result
 
     def discover_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
-        result.update(self._discover_global_skill())
-        result.update(self._discover_project_skills())
-        result.update(self._discover_plugin_skills())
-        result.update(self._discover_plugin_manifest_skills())
+        self._merge_skill_results(result, self._discover_project_skills, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_skill_results(result, self._discover_global_skill, DiscoveryLocationScope.USER)
+        self._merge_skill_results(result, self._discover_plugin_skills, DiscoveryLocationScope.EXTENSION_PLUGIN)
+        self._merge_skill_results(
+            result, self._discover_plugin_manifest_skills, DiscoveryLocationScope.EXTENSION_PLUGIN
+        )
         # NOTE: enterprise/managed skills are a documented Claude Code scope (the
         # "Enterprise" tier in the skills hierarchy, which overrides personal and
         # project skills) but are intentionally NOT discovered here. Unlike

--- a/src/agent_scan/agents/claude_desktop.py
+++ b/src/agent_scan/agents/claude_desktop.py
@@ -59,7 +59,7 @@ from agent_scan.agents.base import (
     McpConfigsResult,
     SkillsDirsResult,
 )
-from agent_scan.models import CouldNotParseMCPConfig
+from agent_scan.models import CouldNotParseMCPConfig, DiscoveryLocationScope
 from agent_scan.well_known_clients import expand_path
 
 logger = logging.getLogger(__name__)
@@ -107,6 +107,11 @@ class ClaudeDesktopDiscoverer(AgentDiscoverer):
         return None
 
     def discover_mcp_servers(self) -> McpConfigsResult:
+        result: McpConfigsResult = {}
+        self._merge_mcp_results(result, self._discover_user_mcp_servers, DiscoveryLocationScope.USER)
+        return result
+
+    def _discover_user_mcp_servers(self) -> McpConfigsResult:
         """Parse the top-level ``mcpServers`` map from ``claude_desktop_config.json``.
 
         Mirrors ``ClaudeCodeDiscoverer._discover_global_mcp_servers``: a missing

--- a/src/agent_scan/agents/codex.py
+++ b/src/agent_scan/agents/codex.py
@@ -33,6 +33,7 @@ from agent_scan.agents.base import (
 from agent_scan.models import (
     ClaudeConfigFile,
     CouldNotParseMCPConfig,
+    DiscoveryLocationScope,
     PluginMCPConfigFile,
 )
 from agent_scan.skill_client import inspect_skills_dir
@@ -106,22 +107,27 @@ class CodexDiscoverer(AgentDiscoverer):
         """MCP servers across every on-disk layer: user + profile + system config,
         plugins, and each registered project."""
         result: McpConfigsResult = {}
-        result.update(self._discover_user_mcp_servers())
-        result.update(self._discover_profile_mcp_servers())
-        result.update(self._discover_system_mcp_servers())
-        result.update(self._discover_plugin_mcp_servers())
-        result.update(self._discover_plugin_manifest_mcp_servers())
-        result.update(self._discover_project_mcp_servers())
+        self._merge_mcp_results(result, self._discover_project_mcp_servers, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_mcp_results(result, self._discover_user_mcp_servers, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_profile_mcp_servers, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_plugin_mcp_servers, DiscoveryLocationScope.EXTENSION_PLUGIN)
+        self._merge_mcp_results(
+            result, self._discover_plugin_manifest_mcp_servers, DiscoveryLocationScope.EXTENSION_PLUGIN
+        )
+        self._merge_mcp_results(result, self._discover_system_mcp_servers, DiscoveryLocationScope.SYSTEM)
         return result
 
     def discover_skills(self) -> SkillsDirsResult:
         """Skills from the documented user/admin dirs, installed plugins, and every
         registered project."""
         result: SkillsDirsResult = {}
-        result.update(self._discover_global_skills())
-        result.update(self._discover_plugin_skills())
-        result.update(self._discover_plugin_manifest_skills())
-        result.update(self._discover_project_skills())
+        self._merge_skill_results(result, self._discover_project_skills, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_skill_results(result, self._discover_user_skills, DiscoveryLocationScope.USER)
+        self._merge_skill_results(result, self._discover_plugin_skills, DiscoveryLocationScope.EXTENSION_PLUGIN)
+        self._merge_skill_results(
+            result, self._discover_plugin_manifest_skills, DiscoveryLocationScope.EXTENSION_PLUGIN
+        )
+        self._merge_skill_results(result, self._discover_system_skills, DiscoveryLocationScope.SYSTEM)
         return result
 
     # --- private: MCP discovery ---
@@ -338,7 +344,7 @@ class CodexDiscoverer(AgentDiscoverer):
 
     # --- private: skills discovery ---
 
-    def _discover_global_skills(self) -> SkillsDirsResult:
+    def _discover_user_skills(self) -> SkillsDirsResult:
         """Scan the user (``~/.agents/skills``), the deprecated-but-still-loaded
         ``<codex_home>/skills`` (kept by Codex for backward compatibility), the
         OpenAI-embedded ``<codex_home>/skills/.system`` cache, and admin
@@ -355,13 +361,24 @@ class CodexDiscoverer(AgentDiscoverer):
             self._codex_home() / "skills",
             self._codex_home() / "skills" / ".system",
             expand_path(Path(self._user_skills_relative), self.home_directory),
-            Path(self._admin_skills_dir),
         )
         for skills_dir in skills_dirs:
             entries = self._scan_skills_dir(skills_dir)
             if entries is not None:
                 result[skills_dir.as_posix()] = entries
         return result
+
+    def _discover_system_skills(self) -> SkillsDirsResult:
+        result: SkillsDirsResult = {}
+        skills_dir = Path(self._admin_skills_dir)
+        entries = self._scan_skills_dir(skills_dir)
+        if entries is not None:
+            result[skills_dir.as_posix()] = entries
+        return result
+
+    def _discover_global_skills(self) -> SkillsDirsResult:
+        """Compatibility helper returning both user-global and system skills."""
+        return {**self._discover_user_skills(), **self._discover_system_skills()}
 
     def _discover_project_skills(self) -> SkillsDirsResult:
         """Scan ``<project>/.agents/skills`` for every registered project and ancestor."""

--- a/src/agent_scan/agents/codex.py
+++ b/src/agent_scan/agents/codex.py
@@ -346,9 +346,10 @@ class CodexDiscoverer(AgentDiscoverer):
 
     def _discover_user_skills(self) -> SkillsDirsResult:
         """Scan the user (``~/.agents/skills``), the deprecated-but-still-loaded
-        ``<codex_home>/skills`` (kept by Codex for backward compatibility), the
-        OpenAI-embedded ``<codex_home>/skills/.system`` cache, and admin
-        (``/etc/codex/skills``) skill dirs; missing/non-dir/unreadable paths are skipped.
+        ``<codex_home>/skills`` (kept by Codex for backward compatibility), and the
+        OpenAI-embedded ``<codex_home>/skills/.system`` cache; missing/non-dir/
+        unreadable paths are skipped. The admin dir is system scope and lives in
+        :meth:`_discover_system_skills`.
         These ``<codex_home>``-rooted dirs follow ``CODEX_HOME``, so a relocated home is
         covered where the legacy pipeline only scans the literal ``~/.codex/skills``.
 
@@ -375,10 +376,6 @@ class CodexDiscoverer(AgentDiscoverer):
         if entries is not None:
             result[skills_dir.as_posix()] = entries
         return result
-
-    def _discover_global_skills(self) -> SkillsDirsResult:
-        """Compatibility helper returning both user-global and system skills."""
-        return {**self._discover_user_skills(), **self._discover_system_skills()}
 
     def _discover_project_skills(self) -> SkillsDirsResult:
         """Scan ``<project>/.agents/skills`` for every registered project and ancestor."""

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -12,7 +12,7 @@ from agent_scan.agents.base import (
     McpConfigsResult,
     SkillsDirsResult,
 )
-from agent_scan.models import MCPConfig, OpenCodeConfigFile
+from agent_scan.models import DiscoveryLocationScope, MCPConfig, OpenCodeConfigFile
 from agent_scan.well_known_clients import expand_path
 
 logger = logging.getLogger(__name__)
@@ -195,19 +195,30 @@ class OpenCodeDiscoverer(AgentDiscoverer):
 
     def discover_mcp_servers(self) -> McpConfigsResult:
         result: McpConfigsResult = {}
-        result.update(self._discover_global_mcp_servers())
-        result.update(self._discover_project_mcp_servers())
-        result.update(self._discover_managed_mcp_servers())
-        result.update(self._discover_env_override_mcp_servers())
+        self._merge_mcp_results(result, self._discover_project_mcp_servers, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_mcp_results(result, self._discover_global_mcp_servers, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_env_override_mcp_servers, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_managed_mcp_servers, DiscoveryLocationScope.SYSTEM)
         return result
 
     def discover_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
-        result.update(self._discover_global_skills())
-        result.update(self._discover_project_skills())
-        result.update(self._discover_managed_skills())
-        result.update(self._discover_config_skills_paths())
-        result.update(self._discover_cached_url_skills())
+        self._merge_skill_results(result, self._discover_project_skills, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_skill_results(result, self._discover_global_skills, DiscoveryLocationScope.USER)
+        self._merge_skill_results(result, self._discover_cached_url_skills, DiscoveryLocationScope.USER)
+        self._merge_scoped_skill_results(
+            result,
+            self._discover_config_skills_paths(DiscoveryLocationScope.PROJECT_WORKSPACE),
+        )
+        self._merge_scoped_skill_results(
+            result,
+            self._discover_config_skills_paths(DiscoveryLocationScope.USER),
+        )
+        self._merge_skill_results(result, self._discover_managed_skills, DiscoveryLocationScope.SYSTEM)
+        self._merge_scoped_skill_results(
+            result,
+            self._discover_config_skills_paths(DiscoveryLocationScope.SYSTEM),
+        )
         return result
 
     # --- folder resolution ---
@@ -589,24 +600,32 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         opencode honors it is picked up. The file may or may not exist;
         ``_load_json_file`` handles missing/unreadable files quietly.
         """
-        candidates: list[Path] = []
-        for base in self._global_config_dirs():
-            for filename in _CONFIG_FILENAMES:
-                candidates.append(base / filename)
-        for project in self._discovery_paths_with_ancestors():
-            for base in self._project_config_bases(project):
+        return [path for path, _scope in self._iter_scoped_candidate_config_files()]
+
+    def _iter_scoped_candidate_config_files(
+        self, source_scope: DiscoveryLocationScope | None = None
+    ) -> list[tuple[Path, DiscoveryLocationScope]]:
+        candidates: list[tuple[Path, DiscoveryLocationScope]] = []
+        if source_scope in (None, DiscoveryLocationScope.USER):
+            for base in self._global_config_dirs():
                 for filename in _CONFIG_FILENAMES:
-                    candidates.append(base / filename)
-        managed = self._managed_config_dir()
-        if managed is not None:
-            for filename in _CONFIG_FILENAMES:
-                candidates.append(managed / filename)
-        env_path = self._opencode_config_env_path()
-        if env_path is not None:
-            candidates.append(env_path)
+                    candidates.append((base / filename, DiscoveryLocationScope.USER))
+            env_path = self._opencode_config_env_path()
+            if env_path is not None:
+                candidates.append((env_path, DiscoveryLocationScope.USER))
+        if source_scope in (None, DiscoveryLocationScope.PROJECT_WORKSPACE):
+            for project in self._discovery_paths_with_ancestors():
+                for base in self._project_config_bases(project):
+                    for filename in _CONFIG_FILENAMES:
+                        candidates.append((base / filename, DiscoveryLocationScope.PROJECT_WORKSPACE))
+        if source_scope in (None, DiscoveryLocationScope.SYSTEM):
+            managed = self._managed_config_dir()
+            if managed is not None:
+                for filename in _CONFIG_FILENAMES:
+                    candidates.append((managed / filename, DiscoveryLocationScope.SYSTEM))
         return candidates
 
-    def _discover_config_skills_paths(self) -> SkillsDirsResult:
+    def _discover_config_skills_paths(self, source_scope: DiscoveryLocationScope | None = None) -> SkillsDirsResult:
         """Scan every ``skills.paths`` entry referenced from any opencode.json.
 
         Per ``packages/core/src/v1/config/skills.ts``:
@@ -630,8 +649,10 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         # opencode's instance dirs (the db ``worktree`` leaves); computed once so
         # the relative-entry resolution below doesn't re-read the SQLite db per
         # candidate config file.
-        worktrees = self._all_discovery_folders()
-        for config_path in self._iter_candidate_config_files():
+        worktrees = (
+            self._all_discovery_folders() if self._scope_enabled(DiscoveryLocationScope.PROJECT_WORKSPACE) else []
+        )
+        for config_path, config_scope in self._iter_scoped_candidate_config_files(source_scope):
             data = self._load_json_file(config_path)
             if not isinstance(data, dict):
                 continue
@@ -644,8 +665,15 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             for entry in paths:
                 if not isinstance(entry, str) or not entry:
                     continue
+                is_project_relative = entry != "~" and not entry.startswith("~/") and not Path(entry).is_absolute()
+                result_scope = DiscoveryLocationScope.PROJECT_WORKSPACE if is_project_relative else config_scope
+                if not self._scope_enabled(result_scope):
+                    continue
                 for resolved in self._resolve_skills_path_entry(entry, worktrees):
-                    self._record_skills_at(result, resolved)
+                    entries = self._scan_skills_dir(resolved)
+                    if entries is not None:
+                        key = resolved.as_posix()
+                        result[key] = self._scope_skill_results({key: entries}, result_scope)[key]
         return result
 
     def _resolve_skills_path_entry(self, entry: str, worktrees: list[Path]) -> list[Path]:

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -678,7 +678,8 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         # opencode's instance dirs (the db ``worktree`` leaves); computed once so
         # the relative-entry resolution below doesn't re-read the SQLite db per
         # candidate config file.
-        worktrees = self._project_worktrees() if self._scope_enabled(DiscoveryLocationScope.PROJECT_WORKSPACE) else []
+        # Even excluded projects can supply relative references to user locations.
+        worktrees = self._project_worktrees()
         for config_path, config_scope in self._iter_scoped_candidate_config_files(source_scope):
             data = self._load_json_file(config_path)
             if not isinstance(data, dict):
@@ -694,18 +695,14 @@ class OpenCodeDiscoverer(AgentDiscoverer):
                     continue
                 is_project_relative = not _is_home_skills_entry(entry) and not _is_rooted_skills_entry(entry)
                 declared_scope = DiscoveryLocationScope.PROJECT_WORKSPACE if is_project_relative else config_scope
-                if not self._scope_enabled(declared_scope):
-                    continue
                 for resolved in self._resolve_skills_path_entry(entry, worktrees):
+                    key = resolved.as_posix()
+                    entry_scope = self._resolve_entry_scope(key, declared_scope)
+                    if not self._scope_enabled(entry_scope):
+                        continue
                     entries = self._scan_skills_dir(resolved)
                     if entries is not None:
-                        key = resolved.as_posix()
-                        # ``_scope_skill_results`` re-checks the scope against where the
-                        # entry actually resolved, so a config cannot label a location it
-                        # does not own; it drops the key when that demotes into a skip.
-                        scoped = self._scope_skill_results({key: entries}, declared_scope)
-                        if key in scoped:
-                            result[key] = scoped[key]
+                        result.update(self._scope_skill_results({key: entries}, entry_scope))
         return result
 
     def _project_worktrees(self) -> list[Path]:

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -626,16 +626,6 @@ class OpenCodeDiscoverer(AgentDiscoverer):
 
     # --- skills.paths from user opencode.json (Gap B) ---
 
-    def _iter_candidate_config_files(self) -> list[Path]:
-        """Every opencode config file we'd consider for ``skills.paths`` extraction.
-
-        Covers the same scopes as MCP discovery (global, project, managed,
-        ``$OPENCODE_CONFIG`` env file) so a ``skills.paths`` declared anywhere
-        opencode honors it is picked up. The file may or may not exist;
-        ``_load_json_file`` handles missing/unreadable files quietly.
-        """
-        return [path for path, _scope in self._iter_scoped_candidate_config_files()]
-
     def _iter_scoped_candidate_config_files(
         self, source_scope: DiscoveryLocationScope | None = None
     ) -> list[tuple[Path, DiscoveryLocationScope]]:
@@ -688,9 +678,7 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         # opencode's instance dirs (the db ``worktree`` leaves); computed once so
         # the relative-entry resolution below doesn't re-read the SQLite db per
         # candidate config file.
-        worktrees = (
-            self._all_discovery_folders() if self._scope_enabled(DiscoveryLocationScope.PROJECT_WORKSPACE) else []
-        )
+        worktrees = self._project_worktrees() if self._scope_enabled(DiscoveryLocationScope.PROJECT_WORKSPACE) else []
         for config_path, config_scope in self._iter_scoped_candidate_config_files(source_scope):
             data = self._load_json_file(config_path)
             if not isinstance(data, dict):
@@ -719,6 +707,20 @@ class OpenCodeDiscoverer(AgentDiscoverer):
                         if key in scoped:
                             result[key] = scoped[key]
         return result
+
+    def _project_worktrees(self) -> list[Path]:
+        """Literal opencode instance dirs, cached for this discoverer's lifetime.
+
+        ``_all_discovery_folders`` is uncached and re-reads the ``opencode*.db``
+        SQLite database on every call, and ``discover_skills`` calls
+        ``_discover_config_skills_paths`` three times -- so the db was opened
+        three extra times per discovery, inside the hook's 5s cap. The literal
+        roots (not the ancestor walk) are correct here because opencode joins a
+        relative ``skills.paths`` entry to the instance directory.
+        """
+        if self._project_worktrees_cache is None:
+            self._project_worktrees_cache = self._all_discovery_folders()
+        return self._project_worktrees_cache
 
     def _resolve_skills_path_entry(self, entry: str, worktrees: list[Path]) -> list[Path]:
         """Expand a single ``skills.paths`` entry the way opencode does.

--- a/src/agent_scan/agents/opencode.py
+++ b/src/agent_scan/agents/opencode.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sqlite3
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from agent_scan.agents.base import (
     AgentDiscoverer,
@@ -23,6 +23,26 @@ _OPENCODE_MCP_FORMATS: tuple[type[MCPConfig], ...] = (OpenCodeConfigFile,)
 # opencode accepts either extension; per https://opencode.ai/docs/config the
 # layered-config loader tries each when reading global and project scopes.
 _CONFIG_FILENAMES: tuple[str, ...] = ("opencode.json", "opencode.jsonc")
+
+
+def _is_rooted_skills_entry(entry: str) -> bool:
+    """Whether a ``skills.paths`` entry names a location outside any project.
+
+    ``Path`` is bound to the running platform, so ``Path("/opt/skills")`` is not
+    absolute on Windows (it has no drive) and ``Path("C:/x")`` is not absolute on
+    POSIX. Either way the entry would be treated as project-relative and joined
+    onto every worktree, which both mislabels its scope and resolves it somewhere
+    the config never named. A config file is data, not code running on the host,
+    so both spellings have to be recognised on every platform.
+    """
+    return (
+        PurePosixPath(entry).is_absolute() or PureWindowsPath(entry).is_absolute() or bool(PureWindowsPath(entry).root)
+    )
+
+
+def _is_home_skills_entry(entry: str) -> bool:
+    """Whether the entry is home-relative, in either path spelling."""
+    return entry == "~" or entry.startswith(("~/", "~\\"))
 
 
 class OpenCodeDiscoverer(AgentDiscoverer):
@@ -197,7 +217,7 @@ class OpenCodeDiscoverer(AgentDiscoverer):
         result: McpConfigsResult = {}
         self._merge_mcp_results(result, self._discover_project_mcp_servers, DiscoveryLocationScope.PROJECT_WORKSPACE)
         self._merge_mcp_results(result, self._discover_global_mcp_servers, DiscoveryLocationScope.USER)
-        self._merge_mcp_results(result, self._discover_env_override_mcp_servers, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_env_override_mcp_servers, self._env_override_config_scope())
         self._merge_mcp_results(result, self._discover_managed_mcp_servers, DiscoveryLocationScope.SYSTEM)
         return result
 
@@ -320,6 +340,20 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             program_data = os.environ.get("PROGRAMDATA") or r"C:\ProgramData"
             return Path(program_data) / "opencode"
         return None
+
+    def _env_override_config_scope(self) -> DiscoveryLocationScope:
+        """Location scope of the ``$OPENCODE_CONFIG`` file, which may sit anywhere.
+
+        Labelling it ``user`` unconditionally means a project-local override
+        survives ``--skip-discovery-scopes project_workspace``, while a genuinely
+        relocated global config is silently dropped by
+        ``--skip-discovery-scopes user`` -- the file is never even opened, so no
+        parse error is surfaced either.
+        """
+        env_path = self._opencode_config_env_path()
+        if env_path is None:
+            return DiscoveryLocationScope.USER
+        return self._location_scope_for(env_path)
 
     def _opencode_config_env_path(self) -> Path | None:
         """Resolved ``$OPENCODE_CONFIG`` path on an own-home scan, else ``None``."""
@@ -610,9 +644,14 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             for base in self._global_config_dirs():
                 for filename in _CONFIG_FILENAMES:
                     candidates.append((base / filename, DiscoveryLocationScope.USER))
-            env_path = self._opencode_config_env_path()
-            if env_path is not None:
-                candidates.append((env_path, DiscoveryLocationScope.USER))
+        # ``$OPENCODE_CONFIG`` is scoped by where it points, not by the fact that
+        # it came from the environment, so it belongs to whichever group matches.
+        env_path = self._opencode_config_env_path()
+        if env_path is not None:
+            env_scope = self._env_override_config_scope()
+            if source_scope in (None, env_scope):
+                candidates.append((env_path, env_scope))
+
         if source_scope in (None, DiscoveryLocationScope.PROJECT_WORKSPACE):
             for project in self._discovery_paths_with_ancestors():
                 for base in self._project_config_bases(project):
@@ -665,15 +704,20 @@ class OpenCodeDiscoverer(AgentDiscoverer):
             for entry in paths:
                 if not isinstance(entry, str) or not entry:
                     continue
-                is_project_relative = entry != "~" and not entry.startswith("~/") and not Path(entry).is_absolute()
-                result_scope = DiscoveryLocationScope.PROJECT_WORKSPACE if is_project_relative else config_scope
-                if not self._scope_enabled(result_scope):
+                is_project_relative = not _is_home_skills_entry(entry) and not _is_rooted_skills_entry(entry)
+                declared_scope = DiscoveryLocationScope.PROJECT_WORKSPACE if is_project_relative else config_scope
+                if not self._scope_enabled(declared_scope):
                     continue
                 for resolved in self._resolve_skills_path_entry(entry, worktrees):
                     entries = self._scan_skills_dir(resolved)
                     if entries is not None:
                         key = resolved.as_posix()
-                        result[key] = self._scope_skill_results({key: entries}, result_scope)[key]
+                        # ``_scope_skill_results`` re-checks the scope against where the
+                        # entry actually resolved, so a config cannot label a location it
+                        # does not own; it drops the key when that demotes into a skip.
+                        scoped = self._scope_skill_results({key: entries}, declared_scope)
+                        if key in scoped:
+                            result[key] = scoped[key]
         return result
 
     def _resolve_skills_path_entry(self, entry: str, worktrees: list[Path]) -> list[Path]:
@@ -688,12 +732,11 @@ class OpenCodeDiscoverer(AgentDiscoverer):
           nothing — matching that opencode would never load it from the config
           dir.
         """
-        if entry == "~" or entry.startswith("~/"):
-            return [expand_path(Path(entry), self.home_directory)]
-        candidate = Path(entry)
-        if candidate.is_absolute():
-            return [candidate]
-        return [worktree / candidate for worktree in worktrees]
+        if _is_home_skills_entry(entry):
+            return [expand_path(Path(entry.replace("\\", "/")), self.home_directory)]
+        if _is_rooted_skills_entry(entry):
+            return [Path(entry)]
+        return [worktree / Path(entry) for worktree in worktrees]
 
     # --- URL-pulled skills cache (Gap C) ---
 

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -31,6 +31,7 @@ from agent_scan.agents.base import (
 from agent_scan.models import (
     ClaudeConfigFile,
     CouldNotParseMCPConfig,
+    DiscoveryLocationScope,
     MCPConfig,
     PluginMCPConfigFile,
     RemoteServer,
@@ -303,25 +304,45 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
 
     def discover_mcp_servers(self) -> McpConfigsResult:
         result: McpConfigsResult = {}
-        result.update(self._discover_user_mcp_files())
-        result.update(self._discover_user_settings_mcp())
-        result.update(self._discover_gated_home_settings_mcp())
-        result.update(self._discover_profile_mcp_files())
-        result.update(self._discover_workspace_mcp())
-        result.update(self._discover_agent_config_mcp())
-        result.update(self._discover_extension_mcp_servers())
-        result.update(self._discover_devcontainer_mcp())
-        result.update(self._discover_code_workspace_mcp())
+        self._merge_mcp_results(result, self._discover_workspace_mcp, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_mcp_results(
+            result,
+            lambda: self._discover_agent_config_mcp(include_user=False, include_project=True),
+            DiscoveryLocationScope.PROJECT_WORKSPACE,
+        )
+        self._merge_mcp_results(result, self._discover_devcontainer_mcp, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_mcp_results(result, self._discover_code_workspace_mcp, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_mcp_results(result, self._discover_user_mcp_files, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_user_settings_mcp, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_gated_home_settings_mcp, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(result, self._discover_profile_mcp_files, DiscoveryLocationScope.USER)
+        self._merge_mcp_results(
+            result,
+            lambda: self._discover_agent_config_mcp(include_user=True, include_project=False),
+            DiscoveryLocationScope.USER,
+        )
+        self._merge_mcp_results(result, self._discover_extension_mcp_servers, DiscoveryLocationScope.EXTENSION_PLUGIN)
         return result
 
     def discover_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
-        result.update(self._discover_home_skills_dirs())
-        result.update(self._discover_system_skills_dirs())
-        result.update(self._discover_workspace_skills())
-        result.update(self._discover_extension_skills())
-        result.update(self._discover_settings_skill_locations())
-        result.update(self._discover_code_workspace_skills())
+        self._merge_skill_results(result, self._discover_workspace_skills, DiscoveryLocationScope.PROJECT_WORKSPACE)
+        self._merge_skill_results(
+            result,
+            lambda: self._discover_settings_skill_locations(include_user=False, include_project=True),
+            DiscoveryLocationScope.PROJECT_WORKSPACE,
+        )
+        self._merge_skill_results(
+            result, self._discover_code_workspace_skills, DiscoveryLocationScope.PROJECT_WORKSPACE
+        )
+        self._merge_skill_results(result, self._discover_home_skills_dirs, DiscoveryLocationScope.USER)
+        self._merge_skill_results(
+            result,
+            lambda: self._discover_settings_skill_locations(include_user=True, include_project=False),
+            DiscoveryLocationScope.USER,
+        )
+        self._merge_skill_results(result, self._discover_extension_skills, DiscoveryLocationScope.EXTENSION_PLUGIN)
+        self._merge_skill_results(result, self._discover_system_skills_dirs, DiscoveryLocationScope.SYSTEM)
         return result
 
     def _discover_home_skills_dirs(self) -> SkillsDirsResult:
@@ -627,7 +648,9 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
                 result[mcp_path.as_posix()] = parsed
         return result
 
-    def _discover_agent_config_mcp(self) -> McpConfigsResult:
+    def _discover_agent_config_mcp(
+        self, *, include_user: bool = True, include_project: bool = True
+    ) -> McpConfigsResult:
         """Scan custom-agent / subagent definition files for *inline* ``mcpServers``.
 
         Some forks store agents one-file-per-agent under a dedicated directory —
@@ -657,9 +680,12 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         """
         if not self._agent_config_dir_paths and not self._workspace_agent_config_relative:
             return {}
-        dirs: list[Path] = [expand_path(Path(raw), self.home_directory) for raw in self._agent_config_dir_paths]
-        for root in self._discovery_paths_with_ancestors():
-            dirs.extend(root / rel for rel in self._workspace_agent_config_relative)
+        dirs: list[Path] = []
+        if include_user:
+            dirs.extend(expand_path(Path(raw), self.home_directory) for raw in self._agent_config_dir_paths)
+        if include_project:
+            for root in self._discovery_paths_with_ancestors():
+                dirs.extend(root / rel for rel in self._workspace_agent_config_relative)
         result: McpConfigsResult = {}
         for base in dirs:
             try:
@@ -885,26 +911,33 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
                 result[path.as_posix()] = entries
         return result
 
-    def _settings_files_for_skill_locations(self) -> list[tuple[Path, Path | None]]:
+    def _settings_files_for_skill_locations(
+        self, *, include_user: bool = True, include_project: bool = True
+    ) -> list[tuple[Path, Path | None]]:
         """``(settings.json path, base_dir)`` pairs to scan for skill locations:
         userdata + profile settings (base ``None``) and per-workspace
         ``.vscode/settings.json`` (base = workspace root)."""
         pairs: list[tuple[Path, Path | None]] = []
-        if self._user_settings_file:
+        if include_user and self._user_settings_file:
             for userdata in self._user_data_dirs():
                 pairs.append((userdata / self._user_settings_file, None))
                 for profile in self._profile_dirs(userdata):
                     pairs.append((profile / "settings.json", None))
-        for path in self._discovery_paths_with_ancestors():
-            pairs.append((path / ".vscode" / "settings.json", path))
+        if include_project:
+            for path in self._discovery_paths_with_ancestors():
+                pairs.append((path / ".vscode" / "settings.json", path))
         return pairs
 
-    def _discover_settings_skill_locations(self) -> SkillsDirsResult:
+    def _discover_settings_skill_locations(
+        self, *, include_user: bool = True, include_project: bool = True
+    ) -> SkillsDirsResult:
         """Aggregate ``chat.agentSkillsLocations`` skill dirs across all settings sources."""
         result: SkillsDirsResult = {}
         if not self._settings_skill_locations_enabled:
             return result
-        for path, base_dir in self._settings_files_for_skill_locations():
+        for path, base_dir in self._settings_files_for_skill_locations(
+            include_user=include_user, include_project=include_project
+        ):
             data = self._load_json_file(path)
             if not isinstance(data, dict):
                 continue

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -325,19 +325,15 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
     def discover_skills(self) -> SkillsDirsResult:
         result: SkillsDirsResult = {}
         self._merge_skill_results(result, self._discover_workspace_skills, DiscoveryLocationScope.PROJECT_WORKSPACE)
-        self._merge_skill_results(
+        self._merge_scoped_skill_results(
             result,
-            lambda: self._discover_settings_skill_locations(include_user=False, include_project=True),
-            DiscoveryLocationScope.PROJECT_WORKSPACE,
+            self._discover_settings_skill_locations(include_user=False, include_project=True),
         )
-        self._merge_skill_results(
-            result, self._discover_code_workspace_skills, DiscoveryLocationScope.PROJECT_WORKSPACE
-        )
+        self._merge_scoped_skill_results(result, self._discover_code_workspace_skills())
         self._merge_skill_results(result, self._discover_home_skills_dirs, DiscoveryLocationScope.USER)
-        self._merge_skill_results(
+        self._merge_scoped_skill_results(
             result,
-            lambda: self._discover_settings_skill_locations(include_user=True, include_project=False),
-            DiscoveryLocationScope.USER,
+            self._discover_settings_skill_locations(include_user=True, include_project=False),
         )
         self._merge_skill_results(result, self._discover_extension_skills, DiscoveryLocationScope.EXTENSION_PLUGIN)
         self._merge_skill_results(result, self._discover_system_skills_dirs, DiscoveryLocationScope.SYSTEM)
@@ -886,13 +882,15 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         The setting is a VS Code object map (``{path: bool}``); a bare list is a
         defensive fallback (see :func:`_enabled_skill_location_paths`). Entries may
         be absolute, ``~``-prefixed, or relative (resolved against ``base_dir``, the
-        workspace root for workspace-scoped settings). Only existing directories
-        are surfaced.
+        workspace root for workspace-scoped settings). Resolve each location's
+        scope before scanning, since one settings file can reference both user
+        and project directories even when its own scope is excluded.
         """
         result: SkillsDirsResult = {}
         if not self._settings_skill_locations_enabled or not isinstance(settings, dict):
             return result
         locations = _read_chat_setting(settings, "agentSkillsLocations")
+        declared_scope = DiscoveryLocationScope.USER if base_dir is None else DiscoveryLocationScope.PROJECT_WORKSPACE
         for raw in _enabled_skill_location_paths(locations):
             if raw.startswith("~"):
                 path = expand_path(Path(raw), self.home_directory)
@@ -902,9 +900,13 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
                 path = base_dir / raw
             else:
                 continue
+            key = path.as_posix()
+            entry_scope = self._resolve_entry_scope(key, declared_scope)
+            if not self._scope_enabled(entry_scope):
+                continue
             entries = self._scan_skills_dir(path)
             if entries is not None:
-                result[path.as_posix()] = entries
+                result.update(self._scope_skill_results({key: entries}, entry_scope))
         return result
 
     def _settings_files_for_skill_locations(
@@ -979,6 +981,20 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
         return result
 
     # --- private: .code-workspace multi-root files ---
+
+    @cached_property
+    def _code_workspace_mcp_paths(self) -> set[Path]:
+        """Exact registered files, without granting project scope to their parent dirs."""
+        return {Path(os.path.normpath(path)) for path, _ in self._code_workspace_json_files}
+
+    def _resolve_mcp_entry_scope(self, path: str, declared: DiscoveryLocationScope) -> DiscoveryLocationScope:
+        if (
+            self._code_workspace_enabled
+            and declared is DiscoveryLocationScope.PROJECT_WORKSPACE
+            and Path(os.path.normpath(path)) in self._code_workspace_mcp_paths
+        ):
+            return declared
+        return super()._resolve_mcp_entry_scope(path, declared)
 
     def _code_workspace_files(self) -> list[Path]:
         """``.code-workspace`` files referenced by the ``workspace`` field of any

--- a/src/agent_scan/agents/vscode/base.py
+++ b/src/agent_scan/agents/vscode/base.py
@@ -34,8 +34,6 @@ from agent_scan.models import (
     DiscoveryLocationScope,
     MCPConfig,
     PluginMCPConfigFile,
-    RemoteServer,
-    StdioServer,
     VSCodeConfigFile,
     VSCodeMCPConfig,
 )
@@ -501,9 +499,7 @@ class VSCodeFamilyDiscoverer(AgentDiscoverer, abstract=True):
                     result[candidate.as_posix()] = parsed
         return result
 
-    def _parse_settings_mcp_gated(
-        self, path: Path
-    ) -> list[tuple[str, StdioServer | RemoteServer]] | CouldNotParseMCPConfig | None:
+    def _parse_settings_mcp_gated(self, path: Path) -> McpScanResult:
         """Parse a multi-purpose ``settings.json`` for MCP, gated on the presence
         of actual MCP servers (a top-level ``mcpServers`` or an ``mcp.servers``).
 

--- a/src/agent_scan/agents/vscode/cursor.py
+++ b/src/agent_scan/agents/vscode/cursor.py
@@ -9,6 +9,7 @@ from agent_scan.agents.vscode.base import (
     SkillsDirsResult,
     VSCodeFamilyDiscoverer,
 )
+from agent_scan.models import DiscoveryLocationScope
 from agent_scan.skill_client import inspect_skills_dir
 from agent_scan.well_known_clients import expand_path
 
@@ -102,13 +103,13 @@ class CursorDiscoverer(VSCodeFamilyDiscoverer):
 
     def discover_skills(self) -> SkillsDirsResult:
         result = super().discover_skills()
-        result.update(self._discover_builtin_skills())
-        result.update(self._discover_plugin_skills())
+        self._merge_skill_results(result, self._discover_builtin_skills, DiscoveryLocationScope.USER)
+        self._merge_skill_results(result, self._discover_plugin_skills, DiscoveryLocationScope.EXTENSION_PLUGIN)
         return result
 
     def discover_mcp_servers(self) -> McpConfigsResult:
         result = super().discover_mcp_servers()
-        result.update(self._discover_plugin_mcp_servers())
+        self._merge_mcp_results(result, self._discover_plugin_mcp_servers, DiscoveryLocationScope.EXTENSION_PLUGIN)
         return result
 
     # --- private: installed-plugin walks (~/.cursor/plugins, parity with Claude Code) ---

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -24,8 +24,10 @@ from rich.logging import RichHandler
 from agent_scan.agents import DiscoveryScope
 from agent_scan.consent import collect_consent
 from agent_scan.models import (
+    AUTOMATIC_DISCOVERY_SCOPES,
     FAILURE_CATEGORY_TO_CODE,
     ControlServer,
+    DiscoveryLocationScope,
     InspectedPath,
     McpServerRiskIndexes,
     ScanResponse,
@@ -998,6 +1000,16 @@ def main():
         default=DiscoveryScope.ALL.value,
         help="Discovery data to collect (default: all)",
     )
+    guard_discover_parser.add_argument(
+        "--skip-discovery-scopes",
+        type=_parse_skip_discovery_scopes,
+        default=frozenset(),
+        metavar="CSV",
+        help=(
+            "Comma-separated location scopes to exclude: system, user, project_workspace, "
+            "extension_plugin, or all (default: exclude none)"
+        ),
+    )
     guard_uninstall_parser = guard_subparsers.add_parser(
         "uninstall",
         allow_abbrev=False,
@@ -1277,6 +1289,23 @@ _VALID_FAILURE_CODES = frozenset(FAILURE_CATEGORY_TO_CODE.values())
 def _parse_comma_separated(raw_value: str | None) -> set[str]:
     """Parse a comma-separated CLI option into non-empty, stripped values."""
     return {value.strip() for value in raw_value.split(",") if value.strip()} if raw_value else set()
+
+
+def _parse_skip_discovery_scopes(raw_value: str) -> frozenset[DiscoveryLocationScope]:
+    """Validate the exclusion CSV used only by ``guard discover``."""
+    raw_parts = [value.strip() for value in raw_value.split(",")]
+    if not raw_parts or any(not value for value in raw_parts):
+        raise argparse.ArgumentTypeError("--skip-discovery-scopes requires a non-empty CSV")
+    values = set(raw_parts)
+    allowed = {scope.value for scope in AUTOMATIC_DISCOVERY_SCOPES}
+    unknown = values - allowed - {"all"}
+    if unknown:
+        raise argparse.ArgumentTypeError(f"unknown discovery scope(s): {', '.join(sorted(unknown))}")
+    if "all" in values:
+        if len(values) != 1:
+            raise argparse.ArgumentTypeError("'all' cannot be combined with specific discovery scopes")
+        return AUTOMATIC_DISCOVERY_SCOPES
+    return frozenset(DiscoveryLocationScope(value) for value in values)
 
 
 def _parse_ignore_risks(args, ci_mode: bool) -> set[str]:

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -1188,7 +1188,7 @@ async def run_scan(args, mode: Literal["scan", "inspect"] = "scan") -> ScanRespo
     inspect_args = InspectArgs(
         timeout=server_timeout,
         tokens=tokens,
-        paths=files,
+        paths=files or [],
         all_users=scan_all_users,
         scan_skills=scan_skills,
         discovery_scope=DiscoveryScope.ALL if scan_skills else DiscoveryScope.SERVERS,
@@ -1343,7 +1343,9 @@ def _parse_ignore_failure_codes(args, ci_mode: bool) -> set[str]:
 def _apply_ignore_risks(response: ScanResponse, ignored_risks: set[str]) -> None:
     """Remove ignored risks before rendering and CI exit evaluation."""
     for path in response.scan_path_responses:
-        risk_indexes = [server.risk_indexes for server in path.server_risks]
+        risk_indexes: list[McpServerRiskIndexes | SkillRiskIndexes] = [
+            server.risk_indexes for server in path.server_risks
+        ]
         risk_indexes.extend(skill.risk_indexes for skill in path.skill_risks)
         for indexes in risk_indexes:
             for name in ignored_risks & indexes.__class__.model_fields.keys():

--- a/src/agent_scan/consent.py
+++ b/src/agent_scan/consent.py
@@ -72,11 +72,12 @@ def collect_consent(
         for config_path, mcp_configs in client.mcp_configs.items():
             if isinstance(mcp_configs, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig):
                 continue
-            for server_name, server in mcp_configs:
+            for discovered in mcp_configs:
+                server = discovered.server
                 if isinstance(server, StdioServer):
-                    stdio_items.append((config_path, server_name, server))
+                    stdio_items.append((config_path, discovered.name, server))
                 elif isinstance(server, RemoteServer):
-                    remote_items.append((config_path, server_name, server))
+                    remote_items.append((config_path, discovered.name, server))
 
     if not stdio_items and not remote_items:
         return set()

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -32,6 +32,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 lacks stdlib TOML
 
 from agent_scan.agents import DiscoveryScope
 from agent_scan.hook_events import HOOK_CLIENTS, send_hook_event
+from agent_scan.models import DiscoveryLocationScope
 from agent_scan.pushkeys import (
     GuardEnabledAccessDeniedError,
     _is_localhost,
@@ -411,6 +412,7 @@ def _run_discover(args) -> int:
         session_marker=session_id or "session-start-server-discovery",
         target_folders=target_folders,
         discovery_scope=getattr(args, "scope", DiscoveryScope.ALL),
+        skip_discovery_scopes=getattr(args, "skip_discovery_scopes", frozenset()) or None,
     )
     return 0 if success else 1
 
@@ -1140,7 +1142,7 @@ def _detect_install(path: Path, events: list[str], commands: Callable[[dict], It
 
 
 def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> list[dict]:
-    """Serialize discovered clients exactly as ``scan`` serializes them for analysis."""
+    """Serialize discovered clients in scan shape plus Guard-only location scope."""
     from agent_scan.inspect import (
         _config_error_to_scan_error,
         _inspection_component_name,
@@ -1151,21 +1153,25 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
     from agent_scan.verify_api import build_scan_request
 
     inspected_paths: list[InspectedPath] = []
+    discovered_scopes: list[list[str]] = []
     for client in clients_to_inspect:
         servers: list[InspectedServer] = []
+        server_scopes: list[str] = []
         config_errors: list[ScanError] = []
         for config_path, discovered in client.mcp_configs.items():
             if isinstance(discovered, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig):
                 config_errors.append(_config_error_to_scan_error(discovered))
                 continue
-            servers.extend(
-                InspectedServer(
-                    name=_inspection_component_name(name, "server", config_path),
-                    config_path=config_path,
-                    server=server,
+            for discovered_server in discovered:
+                name, server = discovered_server
+                servers.append(
+                    InspectedServer(
+                        name=_inspection_component_name(name, "server", config_path),
+                        config_path=config_path,
+                        server=server,
+                    )
                 )
-                for name, server in discovered
-            )
+                server_scopes.append(discovered_server.scope.value)
         inspected_paths.append(
             InspectedPath(
                 client=client.name,
@@ -1174,13 +1180,23 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
                 error=_join_scan_errors(config_errors),
             )
         )
-    return [request.model_dump(mode="json") for request in build_scan_request(inspected_paths).scan_path_requests]
+        discovered_scopes.append(server_scopes)
+
+    payloads: list[dict] = []
+    requests = build_scan_request(inspected_paths).scan_path_requests
+    for request, scopes in zip(requests, discovered_scopes, strict=True):
+        payload = request.model_dump(mode="json")
+        for server, scope in zip(payload["servers"], scopes, strict=True):
+            server["scope"] = scope
+        payloads.append(payload)
+    return payloads
 
 
 def _discover_servers_payload(
     target_folders: list[str] | None = None,
     *,
     discovery_scope: DiscoveryScope = DiscoveryScope.ALL,
+    skip_discovery_scopes: set[DiscoveryLocationScope] | frozenset[DiscoveryLocationScope] | None = None,
 ) -> list[dict]:
     import asyncio
 
@@ -1193,6 +1209,7 @@ def _discover_servers_payload(
         paths=[],
         discovery_scope=discovery_scope,
         target_folders=target_folders or [],
+        skip_discovery_scopes=skip_discovery_scopes or set(),
     )
     clients_to_inspect, _, _ = _run_with_timeout(
         lambda: asyncio.run(pipelines.discover_clients_to_inspect(inspect_args)),
@@ -1311,6 +1328,7 @@ def _send_servers_discovered_event(
     session_marker: str = "hooks-setup",
     target_folders: list[str] | None = None,
     discovery_scope: DiscoveryScope = DiscoveryScope.ALL,
+    skip_discovery_scopes: set[DiscoveryLocationScope] | frozenset[DiscoveryLocationScope] | None = None,
     max_retries: int = 1,
 ) -> bool:
     """Discover MCP servers and send an install- or session-scoped discovery event.
@@ -1321,7 +1339,14 @@ def _send_servers_discovered_event(
     rich.print("[dim]Discovering MCP servers...[/dim]")
     started = time.monotonic()
     try:
-        servers = _discover_servers_payload(target_folders, discovery_scope=discovery_scope)
+        if skip_discovery_scopes is None:
+            servers = _discover_servers_payload(target_folders, discovery_scope=discovery_scope)
+        else:
+            servers = _discover_servers_payload(
+                target_folders,
+                discovery_scope=discovery_scope,
+                skip_discovery_scopes=skip_discovery_scopes,
+            )
     except Exception as e:
         rich.print(f"[yellow]Warning:[/yellow] Could not discover MCP servers: {e}")
         return False
@@ -1566,6 +1591,7 @@ class _HookInvocation(NamedTuple):
     tenant_id: str = ""
     agent_scan_command: str = ""
     scope: str = ""
+    skip_discovery_scopes: str = ""
     quote_client: bool = False
 
 
@@ -1585,6 +1611,8 @@ def _render_posix_command(invocation: _HookInvocation) -> str:
     parts.append(f"--client {client}")
     if invocation.scope:
         parts.append(f"--scope {invocation.scope}")
+    if invocation.skip_discovery_scopes:
+        parts.append(f"--skip-discovery-scopes {invocation.skip_discovery_scopes}")
     return " ".join(parts)
 
 
@@ -1606,6 +1634,8 @@ def _render_powershell_command(invocation: _HookInvocation) -> str:
         parts.extend(["-AgentScanCommand", _ps_quote(invocation.agent_scan_command)])
     if invocation.scope:
         parts.extend(["-Scope", invocation.scope])
+    if invocation.skip_discovery_scopes:
+        parts.extend(["-SkipDiscoveryScopes", invocation.skip_discovery_scopes])
     return " ".join(parts)
 
 
@@ -1628,6 +1658,8 @@ def _render_argv(invocation: _HookInvocation) -> tuple[list[str], dict[str, str]
             argv.extend(["-AgentScanCommand", invocation.agent_scan_command])
         if invocation.scope:
             argv.extend(["-Scope", invocation.scope])
+        if invocation.skip_discovery_scopes:
+            argv.extend(["-SkipDiscoveryScopes", invocation.skip_discovery_scopes])
         return argv, None
 
     env = {
@@ -1644,6 +1676,8 @@ def _render_argv(invocation: _HookInvocation) -> tuple[list[str], dict[str, str]
     argv = ["bash", str(invocation.script_path), "--client", invocation.hook_client]
     if invocation.scope:
         argv.extend(["--scope", invocation.scope])
+    if invocation.skip_discovery_scopes:
+        argv.extend(["--skip-discovery-scopes", invocation.skip_discovery_scopes])
     return argv, env
 
 
@@ -1704,6 +1738,7 @@ def _build_discover_hook_command(
         machine_id=machine_id,
         agent_scan_command=agent_scan_command,
         scope="servers",
+        skip_discovery_scopes=DiscoveryLocationScope.PROJECT_WORKSPACE.value,
         quote_client=True,
     )
     if IS_WINDOWS:

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -412,7 +412,7 @@ def _run_discover(args) -> int:
         session_marker=session_id or "session-start-server-discovery",
         target_folders=target_folders,
         discovery_scope=getattr(args, "scope", DiscoveryScope.ALL),
-        skip_discovery_scopes=getattr(args, "skip_discovery_scopes", frozenset()) or None,
+        skip_discovery_scopes=getattr(args, "skip_discovery_scopes", frozenset()),
     )
     return 0 if success else 1
 
@@ -1329,14 +1329,11 @@ def _send_servers_discovered_event(
     rich.print("[dim]Discovering MCP servers...[/dim]")
     started = time.monotonic()
     try:
-        if skip_discovery_scopes is None:
-            servers = _discover_servers_payload(target_folders, discovery_scope=discovery_scope)
-        else:
-            servers = _discover_servers_payload(
-                target_folders,
-                discovery_scope=discovery_scope,
-                skip_discovery_scopes=skip_discovery_scopes,
-            )
+        servers = _discover_servers_payload(
+            target_folders,
+            discovery_scope=discovery_scope,
+            skip_discovery_scopes=skip_discovery_scopes,
+        )
     except Exception as e:
         rich.print(f"[yellow]Warning:[/yellow] Could not discover MCP servers: {e}")
         return False

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1149,8 +1149,8 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
         _join_scan_errors,
     )
     from agent_scan.models import ScanError
-    from agent_scan.models.inspect import GuardInspectedPath, GuardInspectedServer
     from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, UnknownConfigFormat
+    from agent_scan.models.inspect import GuardInspectedPath, GuardInspectedServer
     from agent_scan.verify_api import build_guard_discovery_payloads
 
     inspected_paths: list[GuardInspectedPath] = []
@@ -1600,9 +1600,9 @@ def _render_posix_command(invocation: _HookInvocation) -> str:
     client = _shell_quote(invocation.hook_client) if invocation.quote_client else invocation.hook_client
     parts.append(f"--client {client}")
     if invocation.scope:
-        parts.append(f"--scope {invocation.scope}")
+        parts.append(f"--scope {_shell_quote(invocation.scope)}")
     if invocation.skip_discovery_scopes:
-        parts.append(f"--skip-discovery-scopes {invocation.skip_discovery_scopes}")
+        parts.append(f"--skip-discovery-scopes {_shell_quote(invocation.skip_discovery_scopes)}")
     return " ".join(parts)
 
 
@@ -1623,9 +1623,11 @@ def _render_powershell_command(invocation: _HookInvocation) -> str:
     if invocation.agent_scan_command:
         parts.extend(["-AgentScanCommand", _ps_quote(invocation.agent_scan_command)])
     if invocation.scope:
-        parts.extend(["-Scope", invocation.scope])
+        parts.extend(["-Scope", _ps_quote(invocation.scope)])
     if invocation.skip_discovery_scopes:
-        parts.extend(["-SkipDiscoveryScopes", invocation.skip_discovery_scopes])
+        # Quoted like every other value-bearing flag. The receiving script also
+        # accepts the unquoted array form, which is what the argv path produces.
+        parts.extend(["-SkipDiscoveryScopes", _ps_quote(invocation.skip_discovery_scopes)])
     return " ".join(parts)
 
 

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1148,48 +1148,38 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
         _inspection_component_name,
         _join_scan_errors,
     )
-    from agent_scan.models import InspectedPath, InspectedServer, ScanError
+    from agent_scan.models import ScanError
+    from agent_scan.models.inspect import GuardInspectedPath, GuardInspectedServer
     from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, UnknownConfigFormat
-    from agent_scan.verify_api import build_scan_request
+    from agent_scan.verify_api import build_guard_discovery_payloads
 
-    inspected_paths: list[InspectedPath] = []
-    discovered_scopes: list[list[str]] = []
+    inspected_paths: list[GuardInspectedPath] = []
     for client in clients_to_inspect:
-        servers: list[InspectedServer] = []
-        server_scopes: list[str] = []
+        servers: list[GuardInspectedServer] = []
         config_errors: list[ScanError] = []
         for config_path, discovered in client.mcp_configs.items():
             if isinstance(discovered, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig):
                 config_errors.append(_config_error_to_scan_error(discovered))
                 continue
             for discovered_server in discovered:
-                name, server = discovered_server
                 servers.append(
-                    InspectedServer(
-                        name=_inspection_component_name(name, "server", config_path),
+                    GuardInspectedServer(
+                        name=_inspection_component_name(discovered_server.name, "server", config_path),
                         config_path=config_path,
-                        server=server,
+                        server=discovered_server.server,
+                        scope=discovered_server.scope,
                     )
                 )
-                server_scopes.append(discovered_server.scope.value)
         inspected_paths.append(
-            InspectedPath(
+            GuardInspectedPath(
                 client=client.name,
                 path=client.client_path,
                 servers=servers,
                 error=_join_scan_errors(config_errors),
             )
         )
-        discovered_scopes.append(server_scopes)
 
-    payloads: list[dict] = []
-    requests = build_scan_request(inspected_paths).scan_path_requests
-    for request, scopes in zip(requests, discovered_scopes, strict=True):
-        payload = request.model_dump(mode="json")
-        for server, scope in zip(payload["servers"], scopes, strict=True):
-            server["scope"] = scope
-        payloads.append(payload)
-    return payloads
+    return build_guard_discovery_payloads(inspected_paths)
 
 
 def _discover_servers_payload(

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1150,12 +1150,12 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
     )
     from agent_scan.models import ScanError
     from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, UnknownConfigFormat
-    from agent_scan.models.inspect import GuardInspectedPath, GuardInspectedServer
+    from agent_scan.models.inspect import GuardInspectedServer, InspectedPath, InspectedServer
     from agent_scan.verify_api import build_guard_discovery_payloads
 
-    inspected_paths: list[GuardInspectedPath] = []
+    inspected_paths: list[InspectedPath] = []
     for client in clients_to_inspect:
-        servers: list[GuardInspectedServer] = []
+        servers: list[InspectedServer] = []
         config_errors: list[ScanError] = []
         for config_path, discovered in client.mcp_configs.items():
             if isinstance(discovered, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig):
@@ -1171,7 +1171,7 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
                     )
                 )
         inspected_paths.append(
-            GuardInspectedPath(
+            InspectedPath(
                 client=client.name,
                 path=client.client_path,
                 servers=servers,
@@ -1199,7 +1199,7 @@ def _discover_servers_payload(
         paths=[],
         discovery_scope=discovery_scope,
         target_folders=target_folders or [],
-        skip_discovery_scopes=skip_discovery_scopes or set(),
+        skip_discovery_scopes=frozenset(skip_discovery_scopes or ()),
     )
     clients_to_inspect, _, _ = _run_with_timeout(
         lambda: asyncio.run(pipelines.discover_clients_to_inspect(inspect_args)),

--- a/src/agent_scan/hooks/snyk-agent-guard-discover.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard-discover.ps1
@@ -22,7 +22,10 @@ param(
 
     [Parameter(Mandatory=$false)]
     [ValidateSet("servers","skills","all")]
-    [string]$Scope = "servers"
+    [string]$Scope = "servers",
+
+    [Parameter(Mandatory=$false)]
+    [string]$SkipDiscoveryScopes
 )
 
 $ErrorActionPreference = "Stop"
@@ -37,6 +40,7 @@ $cmd = if ($AgentScanCommand) { $AgentScanCommand } elseif ($env:AGENT_SCAN_COMM
 if (-not $cmd) { exit 0 }
 
 $arguments = @("guard", "discover", "--client", $Client, "--scope", $Scope)
+if ($SkipDiscoveryScopes) { $arguments += @("--skip-discovery-scopes", $SkipDiscoveryScopes) }
 
 # Do not read stdin here. Invoking the binary outside a pipeline lets it inherit this
 # process's stdin, so `guard discover` reads the hook payload itself under its own 5s

--- a/src/agent_scan/hooks/snyk-agent-guard-discover.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard-discover.ps1
@@ -24,8 +24,16 @@ param(
     [ValidateSet("servers","skills","all")]
     [string]$Scope = "servers",
 
+    # Declared as [string[]] so both spellings bind correctly: PowerShell parses
+    # a bare `system,user` in argument position as an array (which would coerce
+    # into a [string] by joining on $OFS, yielding "system user" and an exit-2
+    # rejection from the CLI), while a quoted 'system,user' binds as one element.
+    # Rejoined below, so either way the CLI receives the CSV it documents.
+    # ValidatePattern restores the guard its ValidateSet-constrained siblings
+    # have, which also constrains what reaches the Invoke-Expression fallback.
     [Parameter(Mandatory=$false)]
-    [string]$SkipDiscoveryScopes
+    [ValidatePattern('^[a-z_]+(,[a-z_]+)*$')]
+    [string[]]$SkipDiscoveryScopes
 )
 
 $ErrorActionPreference = "Stop"
@@ -40,7 +48,7 @@ $cmd = if ($AgentScanCommand) { $AgentScanCommand } elseif ($env:AGENT_SCAN_COMM
 if (-not $cmd) { exit 0 }
 
 $arguments = @("guard", "discover", "--client", $Client, "--scope", $Scope)
-if ($SkipDiscoveryScopes) { $arguments += @("--skip-discovery-scopes", $SkipDiscoveryScopes) }
+if ($SkipDiscoveryScopes) { $arguments += @("--skip-discovery-scopes", ($SkipDiscoveryScopes -join ',')) }
 
 # Do not read stdin here. Invoking the binary outside a pipeline lets it inherit this
 # process's stdin, so `guard discover` reads the hook payload itself under its own 5s

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -469,7 +469,9 @@ async def _inspect_server_configs(
         if isinstance(servers_or_error, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig):
             candidate_errors.append(_config_error_to_scan_error(servers_or_error))
             continue
-        for name, config in servers_or_error:
+        for discovered_server in servers_or_error:
+            name = discovered_server.name
+            config = discovered_server.server
             inspected_server = await _inspect_server(
                 name,
                 config,

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -11,7 +11,9 @@ from agent_scan.models import (
     CandidateClient,
     ClientToInspect,
     CouldNotParseMCPConfig,
+    DiscoveredServer,
     DiscoveredSkill,
+    DiscoveryLocationScope,
     FileNotFoundConfig,
     InspectedPath,
     InspectedServer,
@@ -81,6 +83,7 @@ async def get_mcp_config_per_client(
     create_file_not_found_error: bool = False,
     *,
     scope: DiscoveryScope = DiscoveryScope.ALL,
+    skip_discovery_scopes: set[DiscoveryLocationScope] | frozenset[DiscoveryLocationScope] | None = None,
 ) -> list[ClientToInspect]:
     """
     Looks for Client (Cursor, VSCode, etc.) across all home directories in the machine.
@@ -90,13 +93,23 @@ async def get_mcp_config_per_client(
     if any(path.startswith("~") for path in client.client_exists_paths):
         for home_directory, username in home_dirs:
             cti = await get_mcp_config_per_home_directory(
-                client, home_directory, create_file_not_found_error, scope=scope
+                client,
+                home_directory,
+                create_file_not_found_error,
+                scope=scope,
+                skip_discovery_scopes=skip_discovery_scopes,
             )
             if cti is not None:
                 cti.username = username
                 ctis.append(cti)
     else:
-        cti = await get_mcp_config_per_home_directory(client, None, create_file_not_found_error, scope=scope)
+        cti = await get_mcp_config_per_home_directory(
+            client,
+            None,
+            create_file_not_found_error,
+            scope=scope,
+            skip_discovery_scopes=skip_discovery_scopes,
+        )
         if cti is not None:
             ctis.append(cti)
     return ctis
@@ -108,6 +121,7 @@ async def get_mcp_config_per_home_directory(
     create_file_not_found_error: bool = False,
     *,
     scope: DiscoveryScope = DiscoveryScope.ALL,
+    skip_discovery_scopes: set[DiscoveryLocationScope] | frozenset[DiscoveryLocationScope] | None = None,
 ) -> ClientToInspect | None:
     """
     Looks for Client (Cursor, VSCode, etc.) config files.
@@ -121,6 +135,35 @@ async def get_mcp_config_per_home_directory(
     scope = DiscoveryScope(scope)
     want_servers = scope in (DiscoveryScope.SERVERS, DiscoveryScope.ALL)
     want_skills = scope in (DiscoveryScope.SKILLS, DiscoveryScope.ALL)
+    skipped = frozenset(DiscoveryLocationScope(value) for value in skip_discovery_scopes or ())
+
+    def location_scope(path: str, overrides: dict[str, DiscoveryLocationScope]) -> DiscoveryLocationScope:
+        return overrides.get(path, client.default_location_scope)
+
+    enabled_mcp_paths = [
+        path for path in client.mcp_config_paths if location_scope(path, client.mcp_config_path_scopes) not in skipped
+    ]
+    enabled_skill_paths = [
+        path for path in client.skills_dir_paths if location_scope(path, client.skills_dir_path_scopes) not in skipped
+    ]
+    enabled_mcp_globs = [
+        pattern
+        for pattern in client.mcp_config_globs
+        if location_scope(pattern, client.mcp_config_glob_scopes) not in skipped
+    ]
+    enabled_skill_globs = [
+        pattern
+        for pattern in client.skills_dir_globs
+        if location_scope(pattern, client.skills_dir_glob_scopes) not in skipped
+    ]
+    has_requested_sources = (want_servers and bool(client.mcp_config_paths or client.mcp_config_globs)) or (
+        want_skills and bool(client.skills_dir_paths or client.skills_dir_globs)
+    )
+    has_enabled_requested_sources = (want_servers and bool(enabled_mcp_paths or enabled_mcp_globs)) or (
+        want_skills and bool(enabled_skill_paths or enabled_skill_globs)
+    )
+    if has_requested_sources and not has_enabled_requested_sources:
+        return None
 
     # check if client exists
     client_path: str | None = None
@@ -140,23 +183,24 @@ async def get_mcp_config_per_home_directory(
     # parse mcp configs
     mcp_configs: dict[
         str,
-        list[tuple[str, StdioServer | RemoteServer]]
-        | FileNotFoundConfig
-        | UnknownConfigFormat
-        | CouldNotParseMCPConfig,
+        list[DiscoveredServer] | FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig,
     ] = {}
 
-    all_mcp_config_paths: list[str] = []
+    all_mcp_config_paths: dict[str, DiscoveryLocationScope] = {}
     if want_servers:
-        all_mcp_config_paths = list(client.mcp_config_paths)
-        for glob_pattern in client.mcp_config_globs:
+        for path in enabled_mcp_paths:
+            all_mcp_config_paths[path] = location_scope(path, client.mcp_config_path_scopes)
+        for glob_pattern in enabled_mcp_globs:
             expanded_glob = str(expand_path(Path(glob_pattern), home_directory))
-            all_mcp_config_paths.extend(_resolve_glob_with_depth(expanded_glob, client.max_glob_depth))
-        all_mcp_config_paths = list(
-            dict.fromkeys(str(expand_path(Path(p), home_directory).resolve()) for p in all_mcp_config_paths)
-        )
+            glob_scope = location_scope(glob_pattern, client.mcp_config_glob_scopes)
+            for match in _resolve_glob_with_depth(expanded_glob, client.max_glob_depth):
+                all_mcp_config_paths[match] = glob_scope
+        all_mcp_config_paths = {
+            str(expand_path(Path(path), home_directory).resolve()): path_scope
+            for path, path_scope in all_mcp_config_paths.items()
+        }
 
-    for mcp_config_path in all_mcp_config_paths:
+    for mcp_config_path, path_scope in all_mcp_config_paths.items():
         mcp_config_path_expanded = expand_path(Path(mcp_config_path), home_directory)
         if not mcp_config_path_expanded.exists():
             if create_file_not_found_error:
@@ -179,7 +223,8 @@ async def get_mcp_config_per_home_directory(
                 if isinstance(server_config, StdioServer):
                     server_config = check_server_signature(server_config)
             mcp_configs[mcp_config_path_expanded.as_posix()] = [
-                (server_name, server) for server_name, server in server_configs_by_name.items()
+                DiscoveredServer(name=server_name, server=server, scope=path_scope)
+                for server_name, server in server_configs_by_name.items()
             ]
         except Exception as e:
             logger.exception(f"Error parsing MCP config file {mcp_config_path_expanded.as_posix()}: {e}")
@@ -192,22 +237,28 @@ async def get_mcp_config_per_home_directory(
     # parse skills dirs
     skills_dirs: dict[str, list[DiscoveredSkill] | FileNotFoundConfig] = {}
 
-    all_skills_dir_paths: list[str] = []
+    all_skills_dir_paths: dict[str, DiscoveryLocationScope] = {}
     if want_skills:
-        all_skills_dir_paths = list(client.skills_dir_paths)
-        for glob_pattern in client.skills_dir_globs:
+        for path in enabled_skill_paths:
+            all_skills_dir_paths[path] = location_scope(path, client.skills_dir_path_scopes)
+        for glob_pattern in enabled_skill_globs:
             expanded_glob = str(expand_path(Path(glob_pattern), home_directory))
+            glob_scope = location_scope(glob_pattern, client.skills_dir_glob_scopes)
             for match in _resolve_glob_with_depth(expanded_glob, client.max_glob_depth):
                 if Path(match).is_dir():
-                    all_skills_dir_paths.append(match)
-        all_skills_dir_paths = list(
-            dict.fromkeys(str(expand_path(Path(p), home_directory).resolve()) for p in all_skills_dir_paths)
-        )
+                    all_skills_dir_paths[match] = glob_scope
+        all_skills_dir_paths = {
+            str(expand_path(Path(path), home_directory).resolve()): path_scope
+            for path, path_scope in all_skills_dir_paths.items()
+        }
 
-    for skills_dir_path in all_skills_dir_paths:
+    for skills_dir_path, path_scope in all_skills_dir_paths.items():
         skills_dir_path_expanded = expand_path(Path(skills_dir_path), home_directory)
         if skills_dir_path_expanded.exists():
-            skills_dirs[skills_dir_path_expanded.as_posix()] = inspect_skills_dir(str(skills_dir_path_expanded))
+            skills_dirs[skills_dir_path_expanded.as_posix()] = [
+                skill.model_copy(update={"scope": path_scope})
+                for skill in inspect_skills_dir(str(skills_dir_path_expanded))
+            ]
         elif create_file_not_found_error:
             skills_dirs[skills_dir_path_expanded.as_posix()] = FileNotFoundConfig(
                 message=f"Skills dir {skills_dir_path_expanded.as_posix()} does not exist"

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -33,6 +33,7 @@ from agent_scan.models import (
     UnknownMCPConfig,
     UserDeclinedError,
 )
+from agent_scan.signed_binary import check_server_signature
 from agent_scan.skill_client import (
     SkillInspectionError,
     collect_skill_files,
@@ -98,9 +99,10 @@ def _discovered_servers(
         scope = path_scope if origin is None else DiscoveryLocationScope.PROJECT_WORKSPACE
         if scope in skipped:
             continue
-        discovered.extend(
-            DiscoveredServer(name=server_name, server=server, scope=scope) for server_name, server in servers.items()
-        )
+        for server_name, server in servers.items():
+            if isinstance(server, StdioServer):
+                server = check_server_signature(server)
+            discovered.append(DiscoveredServer(name=server_name, server=server, scope=scope))
     return discovered
 
 

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -8,6 +8,7 @@ from httpx import HTTPStatusError
 from agent_scan.agents.base import DiscoveryScope
 from agent_scan.mcp_client import check_server, scan_mcp_config_file
 from agent_scan.models import (
+    LOCATION_SCOPE_PRECEDENCE,
     CandidateClient,
     ClientToInspect,
     CouldNotParseMCPConfig,
@@ -18,6 +19,7 @@ from agent_scan.models import (
     InspectedPath,
     InspectedServer,
     InspectedSkill,
+    MCPConfig,
     RemoteServer,
     ScanError,
     ServerHTTPError,
@@ -30,7 +32,6 @@ from agent_scan.models import (
     UnknownMCPConfig,
     UserDeclinedError,
 )
-from agent_scan.signed_binary import check_server_signature
 from agent_scan.skill_client import (
     SkillInspectionError,
     collect_skill_files,
@@ -61,6 +62,80 @@ def _inspection_error_to_scan_error(
         category=error.category,
         server_output=error.server_output if isinstance(error, ServerStartupError | ServerHTTPError) else None,
     )
+
+
+def _servers_by_origin(mcp_config: MCPConfig) -> dict[str | None, dict[str, StdioServer | RemoteServer]]:
+    """Group a parsed config's servers by the block that declared them.
+
+    Almost every config format holds one location scope, so its servers come back
+    under a single ``None`` origin. ``~/.claude.json`` is the exception and
+    reports each ``projects.<path>`` block separately.
+    """
+    by_origin = getattr(mcp_config, "get_servers_by_origin", None)
+    if by_origin is None:
+        return {None: mcp_config.get_servers()}
+    return by_origin()
+
+
+def _discovered_servers(
+    mcp_config: MCPConfig,
+    path_scope: DiscoveryLocationScope,
+    skipped: frozenset[DiscoveryLocationScope],
+) -> list[DiscoveredServer]:
+    """Label each server with the scope of the block that declared it.
+
+    The exclusion is applied per entry rather than per file because a single
+    file can mix scopes: labelling all of ``~/.claude.json`` with one scope makes
+    either its user-global or its project servers wrong, and then
+    ``--skip-discovery-scopes`` filters the wrong half.
+
+    Servers under a project-path key are project-scoped regardless of where the
+    declaring file lives — that nesting is what makes them project config.
+    """
+    discovered: list[DiscoveredServer] = []
+    for origin, servers in _servers_by_origin(mcp_config).items():
+        scope = path_scope if origin is None else DiscoveryLocationScope.PROJECT_WORKSPACE
+        if scope in skipped:
+            continue
+        discovered.extend(
+            DiscoveredServer(name=server_name, server=server, scope=scope) for server_name, server in servers.items()
+        )
+    return discovered
+
+
+def _resolved_key(path: str, home_directory: Path | None) -> str:
+    """Absolute, symlink-resolved key for deduplicating two spellings of one file.
+
+    Resolution is guarded the way ``pipelines`` guards its target folders: these
+    paths include glob matches over trees another user can write to, and a stale
+    mount or a NUL byte would otherwise abort discovery for the whole home. On
+    failure the literal expanded spelling is used, which at worst leaves two keys
+    where there should be one.
+    """
+    expanded = expand_path(Path(path), home_directory)
+    try:
+        return str(expanded.resolve())
+    except (OSError, RuntimeError, ValueError):
+        return str(expanded)
+
+
+def _merge_resolved_scope(
+    resolved: dict[str, DiscoveryLocationScope],
+    key: str,
+    scope: DiscoveryLocationScope,
+) -> None:
+    """Record *scope* for *key*, keeping the higher-precedence label on collision.
+
+    Two declarations can name the same file by different spellings -- an explicit
+    path and a glob that matches it, or a ``~``-prefixed and a relative form.
+    Re-keying by resolved path collapses them, so without a precedence rule the
+    surviving label depends on declaration order: globs are inserted after
+    explicit paths, so a plugin glob would silently relabel a user config.
+    Mirrors what the discoverers do in ``AgentDiscoverer._merge_mcp_results``.
+    """
+    existing = resolved.get(key)
+    if existing is None or LOCATION_SCOPE_PRECEDENCE[scope] > LOCATION_SCOPE_PRECEDENCE[existing]:
+        resolved[key] = scope
 
 
 def _resolve_glob_with_depth(pattern: str, max_depth: int) -> list[str]:
@@ -140,9 +215,18 @@ async def get_mcp_config_per_home_directory(
     def location_scope(path: str, overrides: dict[str, DiscoveryLocationScope]) -> DiscoveryLocationScope:
         return overrides.get(path, client.default_location_scope)
 
-    enabled_mcp_paths = [
-        path for path in client.mcp_config_paths if location_scope(path, client.mcp_config_path_scopes) not in skipped
-    ]
+    def mcp_path_enabled(path: str) -> bool:
+        """Whether any scope this file can yield survives the exclusion.
+
+        A file whose format nests several tiers has to be opened even when its
+        declared scope is excluded, so the per-entry filter in
+        ``_discovered_servers`` can keep the nested scopes that are still wanted.
+        """
+        possible = {location_scope(path, client.mcp_config_path_scopes)}
+        possible |= client.mcp_config_path_nested_scopes.get(path, set())
+        return bool(possible - skipped)
+
+    enabled_mcp_paths = [path for path in client.mcp_config_paths if mcp_path_enabled(path)]
     enabled_skill_paths = [
         path for path in client.skills_dir_paths if location_scope(path, client.skills_dir_path_scopes) not in skipped
     ]
@@ -189,16 +273,16 @@ async def get_mcp_config_per_home_directory(
     all_mcp_config_paths: dict[str, DiscoveryLocationScope] = {}
     if want_servers:
         for path in enabled_mcp_paths:
-            all_mcp_config_paths[path] = location_scope(path, client.mcp_config_path_scopes)
+            _merge_resolved_scope(all_mcp_config_paths, path, location_scope(path, client.mcp_config_path_scopes))
         for glob_pattern in enabled_mcp_globs:
             expanded_glob = str(expand_path(Path(glob_pattern), home_directory))
             glob_scope = location_scope(glob_pattern, client.mcp_config_glob_scopes)
             for match in _resolve_glob_with_depth(expanded_glob, client.max_glob_depth):
-                all_mcp_config_paths[match] = glob_scope
-        all_mcp_config_paths = {
-            str(expand_path(Path(path), home_directory).resolve()): path_scope
-            for path, path_scope in all_mcp_config_paths.items()
-        }
+                _merge_resolved_scope(all_mcp_config_paths, match, glob_scope)
+        resolved_mcp_paths: dict[str, DiscoveryLocationScope] = {}
+        for path, path_scope in all_mcp_config_paths.items():
+            _merge_resolved_scope(resolved_mcp_paths, _resolved_key(path, home_directory), path_scope)
+        all_mcp_config_paths = resolved_mcp_paths
 
     for mcp_config_path, path_scope in all_mcp_config_paths.items():
         mcp_config_path_expanded = expand_path(Path(mcp_config_path), home_directory)
@@ -218,14 +302,7 @@ async def get_mcp_config_per_home_directory(
                 )
                 continue
 
-            server_configs_by_name = mcp_config.get_servers()
-            for server_config in server_configs_by_name.values():
-                if isinstance(server_config, StdioServer):
-                    server_config = check_server_signature(server_config)
-            mcp_configs[mcp_config_path_expanded.as_posix()] = [
-                DiscoveredServer(name=server_name, server=server, scope=path_scope)
-                for server_name, server in server_configs_by_name.items()
-            ]
+            mcp_configs[mcp_config_path_expanded.as_posix()] = _discovered_servers(mcp_config, path_scope, skipped)
         except Exception as e:
             logger.exception(f"Error parsing MCP config file {mcp_config_path_expanded.as_posix()}: {e}")
             mcp_configs[mcp_config_path_expanded.as_posix()] = CouldNotParseMCPConfig(
@@ -240,17 +317,17 @@ async def get_mcp_config_per_home_directory(
     all_skills_dir_paths: dict[str, DiscoveryLocationScope] = {}
     if want_skills:
         for path in enabled_skill_paths:
-            all_skills_dir_paths[path] = location_scope(path, client.skills_dir_path_scopes)
+            _merge_resolved_scope(all_skills_dir_paths, path, location_scope(path, client.skills_dir_path_scopes))
         for glob_pattern in enabled_skill_globs:
             expanded_glob = str(expand_path(Path(glob_pattern), home_directory))
             glob_scope = location_scope(glob_pattern, client.skills_dir_glob_scopes)
             for match in _resolve_glob_with_depth(expanded_glob, client.max_glob_depth):
                 if Path(match).is_dir():
-                    all_skills_dir_paths[match] = glob_scope
-        all_skills_dir_paths = {
-            str(expand_path(Path(path), home_directory).resolve()): path_scope
-            for path, path_scope in all_skills_dir_paths.items()
-        }
+                    _merge_resolved_scope(all_skills_dir_paths, match, glob_scope)
+        resolved_skill_paths: dict[str, DiscoveryLocationScope] = {}
+        for path, path_scope in all_skills_dir_paths.items():
+            _merge_resolved_scope(resolved_skill_paths, _resolved_key(path, home_directory), path_scope)
+        all_skills_dir_paths = resolved_skill_paths
 
     for skills_dir_path, path_scope in all_skills_dir_paths.items():
         skills_dir_path_expanded = expand_path(Path(skills_dir_path), home_directory)

--- a/src/agent_scan/inspect.py
+++ b/src/agent_scan/inspect.py
@@ -8,6 +8,7 @@ from httpx import HTTPStatusError
 from agent_scan.agents.base import DiscoveryScope
 from agent_scan.mcp_client import check_server, scan_mcp_config_file
 from agent_scan.models import (
+    AUTOMATIC_DISCOVERY_SCOPES,
     LOCATION_SCOPE_PRECEDENCE,
     CandidateClient,
     ClientToInspect,
@@ -204,8 +205,12 @@ async def get_mcp_config_per_home_directory(
     If not found, returns None.
 
     ``scope`` gates the two halves the same way ``AgentDiscoverer.discover`` does, so a
-    servers-only request does not pay for the skills glob (and vice versa). Client
-    detection itself always runs, so a client never disappears from a scoped report.
+    servers-only request does not pay for the skills glob (and vice versa).
+
+    Client detection always runs, so an installed agent never disappears from a
+    scoped report -- it comes back with only its in-scope components. The one
+    exception is ``skip_discovery_scopes`` covering every automatic scope, which
+    asks for no discovery at all and so withholds presence too.
     """
     scope = DiscoveryScope(scope)
     want_servers = scope in (DiscoveryScope.SERVERS, DiscoveryScope.ALL)
@@ -240,13 +245,14 @@ async def get_mcp_config_per_home_directory(
         for pattern in client.skills_dir_globs
         if location_scope(pattern, client.skills_dir_glob_scopes) not in skipped
     ]
-    has_requested_sources = (want_servers and bool(client.mcp_config_paths or client.mcp_config_globs)) or (
-        want_skills and bool(client.skills_dir_paths or client.skills_dir_globs)
-    )
-    has_enabled_requested_sources = (want_servers and bool(enabled_mcp_paths or enabled_mcp_globs)) or (
-        want_skills and bool(enabled_skill_paths or enabled_skill_globs)
-    )
-    if has_requested_sources and not has_enabled_requested_sources:
+    # Excluding every automatic scope means "discover nothing", including the
+    # fact that an agent is installed and where -- otherwise the session-start
+    # event still discloses that. Mirrors ``find_discoverers``, which
+    # short-circuits on the same condition. Anything short of that keeps the
+    # client so a caller can tell "installed, nothing in scope" from
+    # "not installed": the pipeline logs a not-present message otherwise, and
+    # derives the scanned username from the surviving clients.
+    if skipped >= AUTOMATIC_DISCOVERY_SCOPES:
         return None
 
     # check if client exists

--- a/src/agent_scan/mcp_client.py
+++ b/src/agent_scan/mcp_client.py
@@ -15,6 +15,7 @@ from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.auth import OAuthClientMetadata
+from pydantic import AnyUrl
 
 from agent_scan.models import (
     ClaudeCodeConfigFile,
@@ -59,11 +60,13 @@ async def streamablehttp_client_without_session(
                 client_name="mcp-scan",
                 grant_types=["authorization_code", "refresh_token"],
                 response_types=["code"],
-                redirect_uris=["http://localhost:3030/callback"],
+                redirect_uris=[AnyUrl("http://localhost:3030/callback")],
             ),
             storage=FileTokenStorage(data=token),
             redirect_handler=handle_redirect,
-            callback_handler=handle_callback,
+            # The SDK's stub types this as a zero-arg callable, but the
+            # implementation invokes it with the redirect URL and state.
+            callback_handler=handle_callback,  # type: ignore[arg-type]
         )
     else:
         oauth_client_provider = None
@@ -100,7 +103,7 @@ async def get_client(
             url=server_config.url,
             headers=server_config.headers,
             # env=server_config.env, #Not supported by MCP yet, but present in vscode
-            timeout=timeout,
+            timeout=timeout,  # type: ignore[arg-type]  # stub says float; None means "no timeout"
         )
     elif isinstance(server_config, RemoteServer) and server_config.type == "http":
         logger.debug(
@@ -131,7 +134,9 @@ async def get_client(
                 stream_server_name=server_name if (stream_stderr and server_name) else None,
                 stream_config_path=config_path if (stream_stderr and server_name) else None,
             )
-        client_cm = stdio_client(server_params, errlog=stderr_capture)
+        # PipeStderrCapture is a file-like wrapper rather than a TextIO, and
+        # ``None`` (no capture) is accepted too; the SDK only writes to it.
+        client_cm = stdio_client(server_params, errlog=stderr_capture)  # type: ignore[arg-type]
     else:
         raise ValueError(f"Invalid server config: {server_config}")
 

--- a/src/agent_scan/models/__init__.py
+++ b/src/agent_scan/models/__init__.py
@@ -6,6 +6,7 @@ here keeps callers independent of that internal layout.
 
 from agent_scan.models.api import *  # noqa: F403
 from agent_scan.models.api import __all__ as _api_models
+from agent_scan.models.discovery import AUTOMATIC_DISCOVERY_SCOPES, DiscoveredServer, DiscoveryLocationScope
 from agent_scan.models.errors import (
     FAILURE_CATEGORY_TO_CODE,
     AnalysisError,
@@ -70,7 +71,9 @@ __all__ = [
     "ConfigWithoutMCP",
     "ControlServer",
     "CouldNotParseMCPConfig",
+    "DiscoveredServer",
     "DiscoveredSkill",
+    "DiscoveryLocationScope",
     "Entity",
     "ErrorCategory",
     "FileNotFoundConfig",
@@ -102,4 +105,5 @@ __all__ = [
     "VSCodeMCPConfig",
     "entity_to_tool",
     "rebalance_command_args",
+    "AUTOMATIC_DISCOVERY_SCOPES",
 ]

--- a/src/agent_scan/models/__init__.py
+++ b/src/agent_scan/models/__init__.py
@@ -6,7 +6,12 @@ here keeps callers independent of that internal layout.
 
 from agent_scan.models.api import *  # noqa: F403
 from agent_scan.models.api import __all__ as _api_models
-from agent_scan.models.discovery import AUTOMATIC_DISCOVERY_SCOPES, DiscoveredServer, DiscoveryLocationScope
+from agent_scan.models.discovery import (
+    AUTOMATIC_DISCOVERY_SCOPES,
+    LOCATION_SCOPE_PRECEDENCE,
+    DiscoveredServer,
+    DiscoveryLocationScope,
+)
 from agent_scan.models.errors import (
     FAILURE_CATEGORY_TO_CODE,
     AnalysisError,
@@ -106,4 +111,5 @@ __all__ = [
     "entity_to_tool",
     "rebalance_command_args",
     "AUTOMATIC_DISCOVERY_SCOPES",
+    "LOCATION_SCOPE_PRECEDENCE",
 ]

--- a/src/agent_scan/models/api/v20260710.py
+++ b/src/agent_scan/models/api/v20260710.py
@@ -11,7 +11,13 @@ from pydantic import BaseModel, Field
 
 from agent_scan.models.api.common import ScanUserInfo
 from agent_scan.models.errors import ScanError
-from agent_scan.models.inspect import InspectedPath, InspectedServer, InspectedSkill
+from agent_scan.models.inspect import (
+    GuardInspectedPath,
+    GuardInspectedServer,
+    InspectedPath,
+    InspectedServer,
+    InspectedSkill,
+)
 from agent_scan.models.mcp import RemoteServer, ServerSignature, StdioServer
 from agent_scan.models.skill import SkillFile
 
@@ -107,6 +113,39 @@ class ScanPathRequest(BaseModel):
             servers=[McpServerRequest.from_inspected(server) for server in inspected.servers],
             skills=[SkillRequest.from_inspected(skill) for skill in inspected.skills],
             error=_error_for_request(inspected.error),
+        )
+
+
+class GuardMcpServerRequest(McpServerRequest):
+    """``McpServerRequest`` plus the location scope, for Guard events only.
+
+    Guard's ``sessionStartServerDiscovery`` event reports where each server was
+    found; the analysis contract does not model scope, and ``analyze_machine``
+    sends the plain ``McpServerRequest`` under the same version header. Keeping
+    the extra field on a subclass means the conversion still happens inside the
+    versioned models -- ``build_scan_request`` documents them as owning it --
+    rather than by mutating an already-serialized payload.
+    """
+
+    scope: str
+
+    @classmethod
+    def from_inspected(cls, inspected: GuardInspectedServer) -> "GuardMcpServerRequest":
+        base = McpServerRequest.from_inspected(inspected)
+        return cls(**base.model_dump(), scope=inspected.scope.value)
+
+
+class GuardScanPathRequest(ScanPathRequest):
+    """``ScanPathRequest`` whose servers carry their location scope."""
+
+    servers: list[GuardMcpServerRequest] = Field(default_factory=list)
+
+    @classmethod
+    def from_inspected(cls, inspected: GuardInspectedPath) -> "GuardScanPathRequest":
+        base = ScanPathRequest.from_inspected(inspected)
+        return cls(
+            **base.model_dump(exclude={"servers"}),
+            servers=[GuardMcpServerRequest.from_inspected(server) for server in inspected.servers],
         )
 
 

--- a/src/agent_scan/models/api/v20260710.py
+++ b/src/agent_scan/models/api/v20260710.py
@@ -10,14 +10,9 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from agent_scan.models.api.common import ScanUserInfo
+from agent_scan.models.discovery import DiscoveryLocationScope
 from agent_scan.models.errors import ScanError
-from agent_scan.models.inspect import (
-    GuardInspectedPath,
-    GuardInspectedServer,
-    InspectedPath,
-    InspectedServer,
-    InspectedSkill,
-)
+from agent_scan.models.inspect import InspectedPath, InspectedServer, InspectedSkill
 from agent_scan.models.mcp import RemoteServer, ServerSignature, StdioServer
 from agent_scan.models.skill import SkillFile
 
@@ -127,25 +122,40 @@ class GuardMcpServerRequest(McpServerRequest):
     rather than by mutating an already-serialized payload.
     """
 
-    scope: str
+    scope: str = DiscoveryLocationScope.CUSTOM.value
 
     @classmethod
-    def from_inspected(cls, inspected: GuardInspectedServer) -> "GuardMcpServerRequest":
+    def from_inspected(cls, inspected: InspectedServer) -> "GuardMcpServerRequest":
+        """Accepts a plain ``InspectedServer`` too, which then carries no scope."""
         base = McpServerRequest.from_inspected(inspected)
-        return cls(**base.model_dump(), scope=inspected.scope.value)
+        scope = getattr(inspected, "scope", DiscoveryLocationScope.CUSTOM)
+        return cls(**base.model_dump(), scope=scope.value)
 
 
-class GuardScanPathRequest(ScanPathRequest):
-    """``ScanPathRequest`` whose servers carry their location scope."""
+class GuardScanPathRequest(BaseModel):
+    """Guard's session-start wire shape: ``ScanPathRequest`` plus per-server scope.
 
+    Deliberately not a subclass of ``ScanPathRequest``: narrowing ``servers`` to
+    the Guard server model would violate the base class's declared type, and
+    letting pydantic serialize subclass instances through a base-typed field
+    silently drops the extra ``scope``. Field parity with ``ScanPathRequest`` is
+    pinned by a test instead.
+    """
+
+    client: str | None = None
+    path: str
     servers: list[GuardMcpServerRequest] = Field(default_factory=list)
+    skills: list[SkillRequest] = Field(default_factory=list)
+    error: ScanError | None = None
 
     @classmethod
-    def from_inspected(cls, inspected: GuardInspectedPath) -> "GuardScanPathRequest":
-        base = ScanPathRequest.from_inspected(inspected)
+    def from_inspected(cls, inspected: InspectedPath) -> "GuardScanPathRequest":
         return cls(
-            **base.model_dump(exclude={"servers"}),
+            client=inspected.client,
+            path=inspected.path,
             servers=[GuardMcpServerRequest.from_inspected(server) for server in inspected.servers],
+            skills=[SkillRequest.from_inspected(skill) for skill in inspected.skills],
+            error=_error_for_request(inspected.error),
         )
 
 

--- a/src/agent_scan/models/discovery.py
+++ b/src/agent_scan/models/discovery.py
@@ -1,0 +1,70 @@
+"""Internal models for location-aware component discovery."""
+
+from collections.abc import Iterator
+from enum import Enum
+
+from pydantic import BaseModel, Field, model_validator
+
+from agent_scan.models.mcp import RemoteServer, StdioServer
+
+
+class DiscoveryLocationScope(str, Enum):
+    """Filesystem/location tier from which a component was discovered."""
+
+    SYSTEM = "system"
+    USER = "user"
+    PROJECT_WORKSPACE = "project_workspace"
+    EXTENSION_PLUGIN = "extension_plugin"
+    CUSTOM = "custom"
+
+
+AUTOMATIC_DISCOVERY_SCOPES = frozenset(
+    {
+        DiscoveryLocationScope.SYSTEM,
+        DiscoveryLocationScope.USER,
+        DiscoveryLocationScope.PROJECT_WORKSPACE,
+        DiscoveryLocationScope.EXTENSION_PLUGIN,
+    }
+)
+
+
+class DiscoveredServer(BaseModel):
+    """An MCP server found locally before inspection.
+
+    Iteration and integer indexing intentionally expose the historical
+    ``(name, server)`` pair so internal callers can migrate without changing
+    inspection or Analysis API models.
+    """
+
+    name: str
+    server: StdioServer | RemoteServer
+    scope: DiscoveryLocationScope = Field(default=DiscoveryLocationScope.CUSTOM)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_pair(cls, value: object) -> object:
+        if isinstance(value, tuple) and len(value) == 2:
+            return {"name": value[0], "server": value[1]}
+        return value
+
+    def __iter__(self) -> Iterator[str | StdioServer | RemoteServer]:
+        yield self.name
+        yield self.server
+
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: int) -> str | StdioServer | RemoteServer:
+        if index == 0 or index == -2:
+            return self.name
+        if index == 1 or index == -1:
+            return self.server
+        raise IndexError(index)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, tuple) and len(other) == 2:
+            return (self.name, self.server) == other
+        return super().__eq__(other)
+
+
+__all__ = ["AUTOMATIC_DISCOVERY_SCOPES", "DiscoveredServer", "DiscoveryLocationScope"]

--- a/src/agent_scan/models/discovery.py
+++ b/src/agent_scan/models/discovery.py
@@ -59,7 +59,14 @@ class DiscoveredServer(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _accept_legacy_pair(cls, value: object) -> object:
-        if isinstance(value, tuple) and len(value) == 2:
+        """Accept the historical ``(name, server)`` pair.
+
+        Lists are accepted as well as tuples: a tuple becomes a list across a
+        JSON round-trip, so a tuple-only check would reject the same value on
+        the way back in. ``scope`` is left at ``CUSTOM``, the not-yet-labelled
+        sentinel that ``_scope_mcp_results`` fills in.
+        """
+        if isinstance(value, tuple | list) and len(value) == 2:
             return {"name": value[0], "server": value[1]}
         return value
 

--- a/src/agent_scan/models/discovery.py
+++ b/src/agent_scan/models/discovery.py
@@ -27,6 +27,22 @@ AUTOMATIC_DISCOVERY_SCOPES = frozenset(
     }
 )
 
+# Which label wins when two declarations name the same resolved path. Higher
+# wins. Lives here rather than in ``agents`` because both discovery phases need
+# it and ``models`` must not import from ``agents``.
+#
+# ``CUSTOM`` ranks highest because it doubles as the "not yet labelled" sentinel
+# (see ``AgentDiscoverer._scope_mcp_results``) *and* as the scope of an explicit
+# ``--path`` scan, which the caller asked for by name and should never lose to an
+# automatically-discovered label.
+LOCATION_SCOPE_PRECEDENCE = {
+    DiscoveryLocationScope.PROJECT_WORKSPACE: 0,
+    DiscoveryLocationScope.USER: 1,
+    DiscoveryLocationScope.EXTENSION_PLUGIN: 2,
+    DiscoveryLocationScope.SYSTEM: 3,
+    DiscoveryLocationScope.CUSTOM: 4,
+}
+
 
 class DiscoveredServer(BaseModel):
     """An MCP server found locally before inspection.
@@ -67,4 +83,9 @@ class DiscoveredServer(BaseModel):
         return super().__eq__(other)
 
 
-__all__ = ["AUTOMATIC_DISCOVERY_SCOPES", "DiscoveredServer", "DiscoveryLocationScope"]
+__all__ = [
+    "AUTOMATIC_DISCOVERY_SCOPES",
+    "LOCATION_SCOPE_PRECEDENCE",
+    "DiscoveredServer",
+    "DiscoveryLocationScope",
+]

--- a/src/agent_scan/models/discovery.py
+++ b/src/agent_scan/models/discovery.py
@@ -63,7 +63,13 @@ class DiscoveredServer(BaseModel):
             return {"name": value[0], "server": value[1]}
         return value
 
-    def __iter__(self) -> Iterator[str | StdioServer | RemoteServer]:
+    # Deliberately incompatible with ``BaseModel.__iter__``, which yields
+    # ``(field_name, value)`` pairs: this shim exposes the historical
+    # ``(name, server)`` pair so callers can migrate to attribute access
+    # incrementally. ``model_dump`` is unaffected (it goes through the
+    # pydantic serializer), but note ``dict(server)`` yields
+    # ``{<server-name>: <server>}`` rather than the field map.
+    def __iter__(self) -> Iterator[str | StdioServer | RemoteServer]:  # type: ignore[override]
         yield self.name
         yield self.server
 

--- a/src/agent_scan/models/inspect.py
+++ b/src/agent_scan/models/inspect.py
@@ -2,6 +2,7 @@
 
 from pydantic import BaseModel, Field
 
+from agent_scan.models.discovery import DiscoveredServer, DiscoveryLocationScope
 from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, ScanError, UnknownConfigFormat
 from agent_scan.models.mcp import RemoteServer, ServerSignature, StdioServer
 from agent_scan.models.skill import DiscoveredSkill, SkillFile
@@ -17,6 +18,11 @@ class CandidateClient(BaseModel):
     mcp_config_globs: list[str] = Field(default_factory=list)
     skills_dir_globs: list[str] = Field(default_factory=list)
     max_glob_depth: int = 6
+    default_location_scope: DiscoveryLocationScope = DiscoveryLocationScope.USER
+    mcp_config_path_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
+    skills_dir_path_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
+    mcp_config_glob_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
+    skills_dir_glob_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
 
 
 class ClientToInspect(BaseModel):
@@ -27,10 +33,7 @@ class ClientToInspect(BaseModel):
     username: str | None = None
     mcp_configs: dict[
         str,
-        list[tuple[str, StdioServer | RemoteServer]]
-        | FileNotFoundConfig
-        | UnknownConfigFormat
-        | CouldNotParseMCPConfig,
+        list[DiscoveredServer] | FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig,
     ]
     skills_dirs: dict[str, list[DiscoveredSkill] | FileNotFoundConfig]
 

--- a/src/agent_scan/models/inspect.py
+++ b/src/agent_scan/models/inspect.py
@@ -23,6 +23,13 @@ class CandidateClient(BaseModel):
     skills_dir_path_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
     mcp_config_glob_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
     skills_dir_glob_scopes: dict[str, DiscoveryLocationScope] = Field(default_factory=dict)
+    mcp_config_path_nested_scopes: dict[str, set[DiscoveryLocationScope]] = Field(
+        default_factory=dict,
+        description="Scopes a config file can yield *in addition* to its declared one, because the "
+        "format nests more than one tier in a single file (``~/.claude.json`` holds user-global "
+        "servers alongside per-project ones). Without this the path-level exclusion would skip the "
+        "file before it is opened and the nested scopes would never be seen.",
+    )
 
 
 class ClientToInspect(BaseModel):

--- a/src/agent_scan/models/inspect.py
+++ b/src/agent_scan/models/inspect.py
@@ -1,6 +1,6 @@
 """Models for the discovery-to-inspection lifecycle and its results."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from agent_scan.models.discovery import DiscoveredServer, DiscoveryLocationScope
 from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, ScanError, UnknownConfigFormat
@@ -30,6 +30,31 @@ class CandidateClient(BaseModel):
         "servers alongside per-project ones). Without this the path-level exclusion would skip the "
         "file before it is opened and the nested scopes would never be seen.",
     )
+
+    @model_validator(mode="after")
+    def _scope_overrides_must_name_declared_paths(self) -> "CandidateClient":
+        """Reject an override whose key is not in the list it overrides.
+
+        The override dicts are keyed by the raw, unexpanded declaration string,
+        so a key that drifts from its list entry is not an error today -- it is
+        a silent no-op that falls back to ``default_location_scope`` (``user``),
+        which is exactly the kind of mislabelling the scope filter then acts on.
+        """
+        for override_field, source_field in (
+            ("mcp_config_path_scopes", "mcp_config_paths"),
+            ("skills_dir_path_scopes", "skills_dir_paths"),
+            ("mcp_config_glob_scopes", "mcp_config_globs"),
+            ("skills_dir_glob_scopes", "skills_dir_globs"),
+            ("mcp_config_path_nested_scopes", "mcp_config_paths"),
+        ):
+            declared = set(getattr(self, source_field))
+            unknown = sorted(set(getattr(self, override_field)) - declared)
+            if unknown:
+                raise ValueError(
+                    f"{self.name}: {override_field} names {unknown} which is not in {source_field}; "
+                    "the override would silently fall back to default_location_scope"
+                )
+        return self
 
 
 class ClientToInspect(BaseModel):

--- a/src/agent_scan/models/inspect.py
+++ b/src/agent_scan/models/inspect.py
@@ -117,9 +117,3 @@ class GuardInspectedServer(InspectedServer):
     """
 
     scope: DiscoveryLocationScope = DiscoveryLocationScope.CUSTOM
-
-
-class GuardInspectedPath(InspectedPath):
-    """``InspectedPath`` whose servers carry their location scope."""
-
-    servers: list[GuardInspectedServer] = Field(default_factory=list)

--- a/src/agent_scan/models/inspect.py
+++ b/src/agent_scan/models/inspect.py
@@ -80,3 +80,21 @@ class InspectedPath(BaseModel):
     servers: list[InspectedServer] = Field(default_factory=list)
     skills: list[InspectedSkill] = Field(default_factory=list)
     error: ScanError | None = None
+
+
+class GuardInspectedServer(InspectedServer):
+    """``InspectedServer`` plus the location scope Guard's discovery event reports.
+
+    Deliberately a subclass rather than a field on ``InspectedServer``: that
+    model is dumped verbatim by ``inspect --json`` (``cli.py``), so adding a
+    field there would change user-facing output, and the analysis contract does
+    not model scope either.
+    """
+
+    scope: DiscoveryLocationScope = DiscoveryLocationScope.CUSTOM
+
+
+class GuardInspectedPath(InspectedPath):
+    """``InspectedPath`` whose servers carry their location scope."""
+
+    servers: list[GuardInspectedServer] = Field(default_factory=list)

--- a/src/agent_scan/models/mcp.py
+++ b/src/agent_scan/models/mcp.py
@@ -6,7 +6,7 @@ import re
 from typing import Annotated, Any, Literal, TypeAlias
 
 from lark import Lark
-from mcp.types import Completion, InitializeResult, Prompt, Resource, ResourceTemplate, Tool
+from mcp.types import InitializeResult, Prompt, Resource, ResourceTemplate, Tool
 from pydantic import (
     AliasChoices,
     BaseModel,
@@ -395,7 +395,10 @@ class ConfigWithoutMCP(MCPConfig):
 # MCP server signature and entity utilities
 # ============================================================================
 
-Entity: TypeAlias = Prompt | Resource | Tool | ResourceTemplate | Completion
+# ``Completion`` is deliberately absent: ``ServerSignature`` has no completions
+# field, so ``entities`` can never yield one, and including it made every
+# ``entity.name`` access unsound (Completion has no name).
+Entity: TypeAlias = Prompt | Resource | Tool | ResourceTemplate
 Metadata: TypeAlias = InitializeResult
 
 

--- a/src/agent_scan/models/mcp.py
+++ b/src/agent_scan/models/mcp.py
@@ -187,17 +187,49 @@ class ClaudeConfigFile(MCPConfig):
 
 
 class ClaudeCodeConfigFile(MCPConfig):
+    """``~/.claude.json``, which mixes two location scopes in one file.
+
+    User-global servers live under the top-level ``mcpServers``; project-scoped
+    servers live under ``projects.<project path>.mcpServers``. ``projects`` stays
+    required so a plain ``{"mcpServers": ...}`` file still falls through to
+    ``ClaudeConfigFile`` in the ``scan_mcp_config_file`` format union.
+    """
+
     model_config = ConfigDict()
     projects: dict[str, ClaudeConfigFile]
+    mcpServers: dict[str, StdioServer | RemoteServer] = Field(default_factory=dict)
+
+    def get_servers_by_origin(self) -> dict[str | None, dict[str, StdioServer | RemoteServer]]:
+        """Servers grouped by the key that declared them.
+
+        ``None`` is the top-level (user-global) group; every other key is a
+        project path. Callers need the origin to pick a location scope, and
+        grouping also keeps a server name that appears in several projects from
+        collapsing to whichever project happened to come last.
+        """
+        origins: dict[str | None, dict[str, StdioServer | RemoteServer]] = {}
+        if self.mcpServers:
+            origins[None] = dict(self.mcpServers)
+        for project_path, project in self.projects.items():
+            servers = project.get_servers()
+            if servers:
+                origins[project_path] = dict(servers)
+        return origins
 
     def get_servers(self) -> dict[str, StdioServer | RemoteServer]:
+        """Flattened view kept for callers that don't care about origin.
+
+        Lossy by construction: a name declared in more than one origin survives
+        once. Prefer ``get_servers_by_origin`` when the origin matters.
+        """
         servers: dict[str, StdioServer | RemoteServer] = {}
-        for proj in self.projects.values():
-            servers.update(proj.get_servers())
+        for origin_servers in self.get_servers_by_origin().values():
+            servers.update(origin_servers)
         return servers
 
     def set_servers(self, servers: dict[str, StdioServer | RemoteServer]) -> None:
         self.projects = {"~": ClaudeConfigFile(mcpServers=servers)}
+        self.mcpServers = {}
 
 
 class VSCodeMCPConfig(MCPConfig):

--- a/src/agent_scan/models/push.py
+++ b/src/agent_scan/models/push.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from mcp.client.auth import TokenStorage
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
-from pydantic import BaseModel, ConfigDict, Field, RootModel, field_validator
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel, field_validator
 from pydantic.alias_generators import to_camel
 
 
@@ -62,7 +62,7 @@ class FileTokenStorage(TokenStorage):
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return OAuthClientInformationFull(
             client_id=self.data.client_id,
-            redirect_uris=["http://localhost:3030/callback"],
+            redirect_uris=[AnyUrl("http://localhost:3030/callback")],
         )
 
     async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:

--- a/src/agent_scan/models/skill.py
+++ b/src/agent_scan/models/skill.py
@@ -5,6 +5,8 @@ Contains models for representing skill files during local discovery and analysis
 
 from pydantic import BaseModel, Field
 
+from agent_scan.models.discovery import DiscoveryLocationScope
+
 
 class DiscoveredSkill(BaseModel):
     """A skill or command found locally and awaiting file collection.
@@ -22,6 +24,10 @@ class DiscoveredSkill(BaseModel):
     path: str = Field(
         description="Path to the skill directory or command file, such as '~/.claude/skills/review' "
         "or '~/.claude/commands/git/commit.md'."
+    )
+    scope: DiscoveryLocationScope = Field(
+        default=DiscoveryLocationScope.CUSTOM,
+        description="Filesystem/location tier from which the skill was discovered.",
     )
 
 

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -16,6 +16,7 @@ from agent_scan.models import (
     ClientToInspect,
     ControlServer,
     DiscoveredSkill,
+    DiscoveryLocationScope,
     InspectedPath,
     ScanError,
     ScanResponse,
@@ -37,6 +38,7 @@ class InspectArgs(BaseModel):
     scan_skills: bool = False
     discovery_scope: DiscoveryScope = DiscoveryScope.ALL
     target_folders: list[str] = Field(default_factory=list)
+    skip_discovery_scopes: set[DiscoveryLocationScope] = Field(default_factory=set)
 
 
 class AnalyzeArgs(BaseModel):
@@ -89,31 +91,37 @@ async def discover_clients_to_inspect(
     else:
         target_folders: list[Path] = []
         seen_target_folders: set[Path] = set()
-        for raw_path in inspect_args.target_folders:
-            target_path = Path(raw_path).expanduser()
-            try:
-                key = target_path.resolve()
-            except (OSError, RuntimeError, ValueError):
-                # Target folders come from untrusted hook-payload JSON, where a NUL byte
-                # raises ValueError; fall back to the literal path so one bad entry cannot
-                # abort the whole discovery.
-                key = target_path
-            if key in seen_target_folders:
-                continue
-            seen_target_folders.add(key)
-            try:
-                exists = key.exists()
-            except (OSError, RuntimeError, ValueError):
-                logger.warning("Skipping inaccessible target folder: %s", target_path)
-                continue
-            if not exists:
-                logger.warning("Skipping non-existent target folder: %s", target_path)
-                continue
-            target_folders.append(target_path)
+        if DiscoveryLocationScope.PROJECT_WORKSPACE not in inspect_args.skip_discovery_scopes:
+            for raw_path in inspect_args.target_folders:
+                target_path = Path(raw_path).expanduser()
+                try:
+                    key = target_path.resolve()
+                except (OSError, RuntimeError, ValueError):
+                    # Target folders come from untrusted hook-payload JSON, where a NUL byte
+                    # raises ValueError; fall back to the literal path so one bad entry cannot
+                    # abort the whole discovery.
+                    key = target_path
+                if key in seen_target_folders:
+                    continue
+                seen_target_folders.add(key)
+                try:
+                    exists = key.exists()
+                except (OSError, RuntimeError, ValueError):
+                    logger.warning("Skipping inaccessible target folder: %s", target_path)
+                    continue
+                if not exists:
+                    logger.warning("Skipping non-existent target folder: %s", target_path)
+                    continue
+                target_folders.append(target_path)
 
         # Phase A — legacy path. Runs for EVERY well-known client including Claude Code.
         for client in get_well_known_clients():
-            ctis = await get_mcp_config_per_client(client, home_dirs_with_users, scope=inspect_args.discovery_scope)
+            ctis = await get_mcp_config_per_client(
+                client,
+                home_dirs_with_users,
+                scope=inspect_args.discovery_scope,
+                skip_discovery_scopes=inspect_args.skip_discovery_scopes,
+            )
             if ctis:
                 clients_to_inspect.extend(ctis)
             else:
@@ -121,7 +129,10 @@ async def discover_clients_to_inspect(
 
         # Phase B — ABC path. Runs sequentially after Phase A and merges into its output.
         for home_directory, username in home_dirs_with_users:
-            for discoverer in find_discoverers(home_directory, target_folders=target_folders):
+            discoverer_kwargs: dict = {"target_folders": target_folders}
+            if inspect_args.skip_discovery_scopes:
+                discoverer_kwargs["skip_discovery_scopes"] = inspect_args.skip_discovery_scopes
+            for discoverer in find_discoverers(home_directory, **discoverer_kwargs):
                 try:
                     cti = discoverer.discover(inspect_args.discovery_scope)
                 except Exception:
@@ -292,6 +303,7 @@ async def client_to_inspect_from_path(
                 client_exists_paths=[path],
                 mcp_config_paths=[],
                 skills_dir_paths=[path],
+                default_location_scope=DiscoveryLocationScope.CUSTOM,
             )
             return await get_mcp_config_per_client(
                 candidate_client, home_dirs=home_dirs, create_file_not_found_error=True
@@ -316,5 +328,6 @@ async def client_to_inspect_from_path(
             client_exists_paths=[path],
             mcp_config_paths=[path],
             skills_dir_paths=[],
+            default_location_scope=DiscoveryLocationScope.CUSTOM,
         )
         return await get_mcp_config_per_client(candidate_client, home_dirs=home_dirs, create_file_not_found_error=True)

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -12,6 +12,7 @@ from agent_scan.inspect import (
     inspect_client,
 )
 from agent_scan.models import (
+    AUTOMATIC_DISCOVERY_SCOPES,
     CandidateClient,
     ClientToInspect,
     ControlServer,
@@ -92,7 +93,8 @@ async def discover_clients_to_inspect(
     else:
         target_folders: list[Path] = []
         seen_target_folders: set[Path] = set()
-        if DiscoveryLocationScope.PROJECT_WORKSPACE not in inspect_args.skip_discovery_scopes:
+        # Roots still classify relocated configs when project traversal is excluded.
+        if not inspect_args.skip_discovery_scopes >= AUTOMATIC_DISCOVERY_SCOPES:
             for raw_path in inspect_args.target_folders:
                 target_path = Path(raw_path).expanduser()
                 try:

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -15,6 +15,7 @@ from agent_scan.models import (
     CandidateClient,
     ClientToInspect,
     ControlServer,
+    DiscoveredServer,
     DiscoveredSkill,
     DiscoveryLocationScope,
     InspectedPath,
@@ -38,7 +39,7 @@ class InspectArgs(BaseModel):
     scan_skills: bool = False
     discovery_scope: DiscoveryScope = DiscoveryScope.ALL
     target_folders: list[str] = Field(default_factory=list)
-    skip_discovery_scopes: set[DiscoveryLocationScope] = Field(default_factory=set)
+    skip_discovery_scopes: frozenset[DiscoveryLocationScope] = Field(default_factory=frozenset)
 
 
 class AnalyzeArgs(BaseModel):
@@ -276,7 +277,7 @@ async def client_to_inspect_from_path(
                 name=path if use_path_as_client_name else "not-available",
                 client_path=path,
                 mcp_configs={
-                    path: [(server_name, server_config)],
+                    path: [DiscoveredServer(name=server_name, server=server_config)],
                 },
                 skills_dirs={},
             )

--- a/src/agent_scan/pipelines.py
+++ b/src/agent_scan/pipelines.py
@@ -130,10 +130,11 @@ async def discover_clients_to_inspect(
 
         # Phase B — ABC path. Runs sequentially after Phase A and merges into its output.
         for home_directory, username in home_dirs_with_users:
-            discoverer_kwargs: dict = {"target_folders": target_folders}
-            if inspect_args.skip_discovery_scopes:
-                discoverer_kwargs["skip_discovery_scopes"] = inspect_args.skip_discovery_scopes
-            for discoverer in find_discoverers(home_directory, **discoverer_kwargs):
+            for discoverer in find_discoverers(
+                home_directory,
+                target_folders=target_folders,
+                skip_discovery_scopes=inspect_args.skip_discovery_scopes,
+            ):
                 try:
                     cti = discoverer.discover(inspect_args.discovery_scope)
                 except Exception:

--- a/src/agent_scan/printer.py
+++ b/src/agent_scan/printer.py
@@ -1,7 +1,7 @@
 import os
 from collections import Counter
 from collections.abc import Sequence
-from typing import overload
+from typing import Any, overload
 
 import rich
 from mcp.types import Prompt, Resource, ResourceTemplate, Tool
@@ -290,8 +290,13 @@ def _sorted_risks(risk_indexes: SkillRiskIndexes) -> list[tuple[str, SkillRiskSc
 
 def _sorted_risks(
     risk_indexes: McpServerRiskIndexes | SkillRiskIndexes,
-) -> list[tuple[str, RiskScore | SkillRiskScore]]:
-    """Return detected risks highest-first, preserving model order for ties."""
+) -> list[tuple[str, Any]]:
+    """Return detected risks highest-first, preserving model order for ties.
+
+    ``Any`` appears only in the implementation signature; callers see the two
+    ``@overload`` declarations above, and mypy requires the implementation to be
+    assignable to both of them.
+    """
     risks = [(name, risk) for name, risk in risk_indexes if risk is not None]
     return sorted(risks, key=lambda item: item[1].score, reverse=True)
 

--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -6,7 +6,7 @@ import os
 import ssl
 import sys
 import traceback
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import aiohttp
@@ -29,7 +29,7 @@ from agent_scan.models.api.v20260710 import (
     SkillRiskResponse,
 )
 from agent_scan.models.errors import ScanError
-from agent_scan.models.inspect import GuardInspectedPath, InspectedPath
+from agent_scan.models.inspect import InspectedPath
 from agent_scan.models.mcp import Entity
 from agent_scan.utils import get_environment, get_relative_path
 from agent_scan.well_known_clients import get_client_from_path
@@ -62,13 +62,15 @@ def build_scan_request(
     return request
 
 
-def _apply_transport_boundary(inspected_path: InspectedPath, path_request: ScanPathRequest) -> None:
+def _apply_transport_boundary(
+    inspected_path: InspectedPath, path_request: ScanPathRequest | GuardScanPathRequest
+) -> None:
     """Infer the client and make the top-level path home-relative."""
     path_request.client = get_client_from_path(inspected_path.path) or path_request.client or inspected_path.path
     path_request.path = get_relative_path(path_request.path)
 
 
-def build_guard_discovery_payloads(inspected_paths: list[GuardInspectedPath]) -> list[dict]:
+def build_guard_discovery_payloads(inspected_paths: list[InspectedPath]) -> list[dict]:
     """Serialize inspected paths for Guard's session-start discovery event.
 
     Same transport boundary as :func:`build_scan_request`, but built from the
@@ -81,7 +83,7 @@ def build_guard_discovery_payloads(inspected_paths: list[GuardInspectedPath]) ->
     return [_guard_path_payload(inspected_path) for inspected_path in inspected_paths]
 
 
-def _guard_path_payload(inspected_path: GuardInspectedPath) -> dict:
+def _guard_path_payload(inspected_path: InspectedPath) -> dict:
     path_request = GuardScanPathRequest.from_inspected(inspected_path)
     _apply_transport_boundary(inspected_path, path_request)
     return path_request.model_dump(mode="json")
@@ -248,7 +250,7 @@ async def _submit_async_analysis(
 
 def _entity_summary(entity: Entity) -> McpEntitySummary:
     if isinstance(entity, Tool):
-        entity_type = "tool"
+        entity_type: Literal["tool", "resource", "resource_template", "prompt"] = "tool"
     elif isinstance(entity, Prompt):
         entity_type = "prompt"
     elif isinstance(entity, Resource):
@@ -263,7 +265,7 @@ def _entity_summary(entity: Entity) -> McpEntitySummary:
 def _skill_file_summary(path: str) -> SkillFileSummary:
     lowered = path.lower()
     if lowered.endswith(".md"):
-        file_type = "instruction"
+        file_type: Literal["instruction", "script", "asset"] = "instruction"
     elif lowered.rsplit(".", 1)[-1] in ("py", "js", "ts", "sh"):
         file_type = "script"
     else:

--- a/src/agent_scan/verify_api.py
+++ b/src/agent_scan/verify_api.py
@@ -16,9 +16,11 @@ from mcp.types import Prompt, Resource, ResourceTemplate, Tool
 
 from agent_scan.models.api.common import ScanUserInfo
 from agent_scan.models.api.v20260710 import (
+    GuardScanPathRequest,
     McpEntitySummary,
     McpServerRequest,
     McpServerRiskResponse,
+    ScanPathRequest,
     ScanPathResponse,
     ScanRequest,
     ScanResponse,
@@ -27,7 +29,7 @@ from agent_scan.models.api.v20260710 import (
     SkillRiskResponse,
 )
 from agent_scan.models.errors import ScanError
-from agent_scan.models.inspect import InspectedPath
+from agent_scan.models.inspect import GuardInspectedPath, InspectedPath
 from agent_scan.models.mcp import Entity
 from agent_scan.utils import get_environment, get_relative_path
 from agent_scan.well_known_clients import get_client_from_path
@@ -56,9 +58,33 @@ def build_scan_request(
         scan_metadata=scan_metadata,
     )
     for inspected_path, path_request in zip(inspected_paths, request.scan_path_requests, strict=True):
-        path_request.client = get_client_from_path(inspected_path.path) or path_request.client or inspected_path.path
-        path_request.path = get_relative_path(path_request.path)
+        _apply_transport_boundary(inspected_path, path_request)
     return request
+
+
+def _apply_transport_boundary(inspected_path: InspectedPath, path_request: ScanPathRequest) -> None:
+    """Infer the client and make the top-level path home-relative."""
+    path_request.client = get_client_from_path(inspected_path.path) or path_request.client or inspected_path.path
+    path_request.path = get_relative_path(path_request.path)
+
+
+def build_guard_discovery_payloads(inspected_paths: list[GuardInspectedPath]) -> list[dict]:
+    """Serialize inspected paths for Guard's session-start discovery event.
+
+    Same transport boundary as :func:`build_scan_request`, but built from the
+    Guard request models so each server carries the location scope the analysis
+    contract does not model. Going through the versioned models keeps them the
+    single owner of the conversion, instead of patching ``scope`` onto an
+    already-serialized ``ScanPathRequest`` by position -- which coupled Guard to
+    ``from_inspected`` never filtering or reordering servers.
+    """
+    return [_guard_path_payload(inspected_path) for inspected_path in inspected_paths]
+
+
+def _guard_path_payload(inspected_path: GuardInspectedPath) -> dict:
+    path_request = GuardScanPathRequest.from_inspected(inspected_path)
+    _apply_transport_boundary(inspected_path, path_request)
+    return path_request.model_dump(mode="json")
 
 
 class SnykTokenError(Exception):

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -4,7 +4,7 @@ import os
 import sys
 from pathlib import Path
 
-from agent_scan.models import CandidateClient
+from agent_scan.models import CandidateClient, DiscoveryLocationScope
 
 # Set up logger for this module
 logger = logging.getLogger(__name__)
@@ -51,6 +51,8 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=["~/.claude/skills"],
         mcp_config_globs=["~/.claude/plugins/cache/**/.mcp.json"],
         skills_dir_globs=["~/.claude/plugins/cache/**/skills"],
+        mcp_config_glob_scopes={"~/.claude/plugins/cache/**/.mcp.json": DiscoveryLocationScope.EXTENSION_PLUGIN},
+        skills_dir_glob_scopes={"~/.claude/plugins/cache/**/skills": DiscoveryLocationScope.EXTENSION_PLUGIN},
     ),
     CandidateClient(
         name="gemini cli",
@@ -68,12 +70,17 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
             "~/.openclaw/workspace/skills",
             ".openclaw/skills",
         ],
+        skills_dir_path_scopes={
+            "~/.openclaw/workspace/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
+            ".openclaw/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
+        },
     ),
     CandidateClient(
         name="amp",
         client_exists_paths=["~/.config/agents", ".amp"],
         mcp_config_paths=[],
         skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
+        skills_dir_path_scopes={".amp/skills": DiscoveryLocationScope.PROJECT_WORKSPACE},
     ),
     CandidateClient(
         name="kiro",
@@ -141,6 +148,8 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=["~/.claude/skills"],
         mcp_config_globs=["~/.claude/plugins/cache/**/.mcp.json"],
         skills_dir_globs=["~/.claude/plugins/cache/**/skills"],
+        mcp_config_glob_scopes={"~/.claude/plugins/cache/**/.mcp.json": DiscoveryLocationScope.EXTENSION_PLUGIN},
+        skills_dir_glob_scopes={"~/.claude/plugins/cache/**/skills": DiscoveryLocationScope.EXTENSION_PLUGIN},
     ),
     CandidateClient(
         name="gemini cli",
@@ -158,12 +167,17 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
             "~/.openclaw/workspace/skills",
             ".openclaw/skills",
         ],
+        skills_dir_path_scopes={
+            "~/.openclaw/workspace/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
+            ".openclaw/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
+        },
     ),
     CandidateClient(
         name="amp",
         client_exists_paths=["~/.config/agents", ".amp"],
         mcp_config_paths=[],
         skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
+        skills_dir_path_scopes={".amp/skills": DiscoveryLocationScope.PROJECT_WORKSPACE},
     ),
     CandidateClient(
         name="kiro",
@@ -238,6 +252,8 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_paths=["~/.claude/skills"],
         mcp_config_globs=["~/.claude/plugins/cache/**/.mcp.json"],
         skills_dir_globs=["~/.claude/plugins/cache/**/skills"],
+        mcp_config_glob_scopes={"~/.claude/plugins/cache/**/.mcp.json": DiscoveryLocationScope.EXTENSION_PLUGIN},
+        skills_dir_glob_scopes={"~/.claude/plugins/cache/**/skills": DiscoveryLocationScope.EXTENSION_PLUGIN},
     ),
     CandidateClient(
         name="gemini cli",
@@ -255,12 +271,17 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
             "~/.openclaw/workspace/skills",
             ".openclaw/skills",
         ],
+        skills_dir_path_scopes={
+            "~/.openclaw/workspace/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
+            ".openclaw/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
+        },
     ),
     CandidateClient(
         name="amp",
         client_exists_paths=["~/.config/agents", ".amp"],
         mcp_config_paths=[],
         skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
+        skills_dir_path_scopes={".amp/skills": DiscoveryLocationScope.PROJECT_WORKSPACE},
     ),
     CandidateClient(
         name="kiro",

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -53,6 +53,9 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_globs=["~/.claude/plugins/cache/**/skills"],
         mcp_config_glob_scopes={"~/.claude/plugins/cache/**/.mcp.json": DiscoveryLocationScope.EXTENSION_PLUGIN},
         skills_dir_glob_scopes={"~/.claude/plugins/cache/**/skills": DiscoveryLocationScope.EXTENSION_PLUGIN},
+        # ``~/.claude.json`` nests per-project servers under ``projects.<path>``
+        # alongside the user-global top-level ``mcpServers``.
+        mcp_config_path_nested_scopes={"~/.claude.json": {DiscoveryLocationScope.PROJECT_WORKSPACE}},
     ),
     CandidateClient(
         name="gemini cli",
@@ -68,19 +71,16 @@ MACOS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
             "~/.clawdbot/skills",
             "~/.openclaw/skills",
             "~/.openclaw/workspace/skills",
-            ".openclaw/skills",
         ],
         skills_dir_path_scopes={
             "~/.openclaw/workspace/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
-            ".openclaw/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
         },
     ),
     CandidateClient(
         name="amp",
-        client_exists_paths=["~/.config/agents", ".amp"],
+        client_exists_paths=["~/.config/agents"],
         mcp_config_paths=[],
-        skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
-        skills_dir_path_scopes={".amp/skills": DiscoveryLocationScope.PROJECT_WORKSPACE},
+        skills_dir_paths=["~/.config/agents/skills"],
     ),
     CandidateClient(
         name="kiro",
@@ -150,6 +150,9 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_globs=["~/.claude/plugins/cache/**/skills"],
         mcp_config_glob_scopes={"~/.claude/plugins/cache/**/.mcp.json": DiscoveryLocationScope.EXTENSION_PLUGIN},
         skills_dir_glob_scopes={"~/.claude/plugins/cache/**/skills": DiscoveryLocationScope.EXTENSION_PLUGIN},
+        # ``~/.claude.json`` nests per-project servers under ``projects.<path>``
+        # alongside the user-global top-level ``mcpServers``.
+        mcp_config_path_nested_scopes={"~/.claude.json": {DiscoveryLocationScope.PROJECT_WORKSPACE}},
     ),
     CandidateClient(
         name="gemini cli",
@@ -165,19 +168,16 @@ LINUX_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
             "~/.clawdbot/skills",
             "~/.openclaw/skills",
             "~/.openclaw/workspace/skills",
-            ".openclaw/skills",
         ],
         skills_dir_path_scopes={
             "~/.openclaw/workspace/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
-            ".openclaw/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
         },
     ),
     CandidateClient(
         name="amp",
-        client_exists_paths=["~/.config/agents", ".amp"],
+        client_exists_paths=["~/.config/agents"],
         mcp_config_paths=[],
-        skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
-        skills_dir_path_scopes={".amp/skills": DiscoveryLocationScope.PROJECT_WORKSPACE},
+        skills_dir_paths=["~/.config/agents/skills"],
     ),
     CandidateClient(
         name="kiro",
@@ -254,6 +254,9 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
         skills_dir_globs=["~/.claude/plugins/cache/**/skills"],
         mcp_config_glob_scopes={"~/.claude/plugins/cache/**/.mcp.json": DiscoveryLocationScope.EXTENSION_PLUGIN},
         skills_dir_glob_scopes={"~/.claude/plugins/cache/**/skills": DiscoveryLocationScope.EXTENSION_PLUGIN},
+        # ``~/.claude.json`` nests per-project servers under ``projects.<path>``
+        # alongside the user-global top-level ``mcpServers``.
+        mcp_config_path_nested_scopes={"~/.claude.json": {DiscoveryLocationScope.PROJECT_WORKSPACE}},
     ),
     CandidateClient(
         name="gemini cli",
@@ -269,19 +272,16 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
             "~/.clawdbot/skills",
             "~/.openclaw/skills",
             "~/.openclaw/workspace/skills",
-            ".openclaw/skills",
         ],
         skills_dir_path_scopes={
             "~/.openclaw/workspace/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
-            ".openclaw/skills": DiscoveryLocationScope.PROJECT_WORKSPACE,
         },
     ),
     CandidateClient(
         name="amp",
-        client_exists_paths=["~/.config/agents", ".amp"],
+        client_exists_paths=["~/.config/agents"],
         mcp_config_paths=[],
-        skills_dir_paths=["~/.config/agents/skills", ".amp/skills"],
-        skills_dir_path_scopes={".amp/skills": DiscoveryLocationScope.PROJECT_WORKSPACE},
+        skills_dir_paths=["~/.config/agents/skills"],
     ),
     CandidateClient(
         name="kiro",

--- a/src/agent_scan/well_known_clients.py
+++ b/src/agent_scan/well_known_clients.py
@@ -304,36 +304,64 @@ WINDOWS_WELL_KNOWN_CLIENTS: list[CandidateClient] = [
 ]
 
 
+def _discovery_identity(client: CandidateClient) -> str:
+    """A stable key covering everything that makes a client's discovery distinct.
+
+    Every discovery-relevant field is included, so two entries that differ only
+    in their glob lists or their location-scope overrides stay distinct. A key
+    that named only the path lists would silently collapse them and apply one
+    platform's scope labels to the other.
+    """
+    return client.model_dump_json(
+        include={
+            "name",
+            "client_exists_paths",
+            "mcp_config_paths",
+            "skills_dir_paths",
+            "mcp_config_globs",
+            "skills_dir_globs",
+            "max_glob_depth",
+            "default_location_scope",
+            "mcp_config_path_scopes",
+            "skills_dir_path_scopes",
+            "mcp_config_glob_scopes",
+            "skills_dir_glob_scopes",
+            "mcp_config_path_nested_scopes",
+        }
+    )
+
+
+def merge_platform_clients(primary: list[CandidateClient], secondary: list[CandidateClient]) -> list[CandidateClient]:
+    """Concatenate two per-OS client lists, dropping structural duplicates.
+
+    On Windows we may also be scanning Linux home directories that live inside
+    WSL distros (exposed as ``\\\\wsl.localhost\\<Distro>\\home\\<user>``). The Linux
+    client definitions use Linux-conventional paths (e.g. ``~/.config/Code``,
+    ``~/.claude.json``), which only match when expanded against a WSL home; the
+    Windows definitions only match against Windows-native homes. Merging both
+    lists gets WSL homes probed with Linux paths, while dropping Linux entries
+    whose discovery rules are identical to an existing Windows entry (e.g.
+    ``cursor`` uses ``~/.cursor/mcp.json`` on both) avoids scanning the same MCP
+    server twice per home.
+    """
+    seen: set[str] = set()
+    merged: list[CandidateClient] = []
+    for client in [*primary, *secondary]:
+        key = _discovery_identity(client)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(client)
+    return merged
+
+
 def get_well_known_clients() -> list[CandidateClient]:
     if sys.platform == "linux" or sys.platform == "linux2":
         return LINUX_WELL_KNOWN_CLIENTS
     elif sys.platform == "darwin":
         return MACOS_WELL_KNOWN_CLIENTS
     elif sys.platform == "win32":
-        # On Windows we may also be scanning Linux home directories that live
-        # inside WSL distros (exposed as \\wsl.localhost\<Distro>\home\<user>).
-        # The Linux client definitions use Linux-conventional paths
-        # (e.g. ~/.config/Code, ~/.claude.json), which only match when
-        # expanded against a WSL home; the Windows definitions only match
-        # against Windows-native homes. Merge both lists so WSL homes get
-        # probed with Linux paths, but drop Linux entries whose discovery
-        # paths are structurally identical to an existing Windows entry
-        # (e.g. `cursor` uses `~/.cursor/mcp.json` on both platforms) to
-        # avoid scanning the same MCP server twice per home.
-        seen: set[tuple[str, tuple[str, ...], tuple[str, ...], tuple[str, ...]]] = set()
-        merged: list[CandidateClient] = []
-        for client in WINDOWS_WELL_KNOWN_CLIENTS + LINUX_WELL_KNOWN_CLIENTS:
-            key = (
-                client.name,
-                tuple(client.client_exists_paths),
-                tuple(client.mcp_config_paths),
-                tuple(client.skills_dir_paths),
-            )
-            if key in seen:
-                continue
-            seen.add(key)
-            merged.append(client)
-        return merged
+        return merge_platform_clients(WINDOWS_WELL_KNOWN_CLIENTS, LINUX_WELL_KNOWN_CLIENTS)
     else:
         return []
 

--- a/tests/e2e/test_guard_install.py
+++ b/tests/e2e/test_guard_install.py
@@ -90,6 +90,8 @@ class TestGuardInstallE2E:
         discover_command = discovery_groups[0]["hooks"][0]["command"]
         discover_script = "snyk-agent-guard-discover.ps1" if os.name == "nt" else "snyk-agent-guard-discover.sh"
         assert discover_script in discover_command
+        assert ("-SkipDiscoveryScopes" if os.name == "nt" else "--skip-discovery-scopes") in discover_command
+        assert "project_workspace" in discover_command
         assert str(config_file) not in discover_command
         assert ("-ConfigFile" if os.name == "nt" else "--file") not in discover_command
         assert [request["body"]["hook_event_name"] for request in _FakeHookServer.requests] == [
@@ -160,6 +162,10 @@ class TestGuardInstallE2E:
         ]
         assert len(discovery_entries) == 1
         assert set(discovery_entries[0]) == {"command"}
+        assert ("-SkipDiscoveryScopes" if os.name == "nt" else "--skip-discovery-scopes") in discovery_entries[0][
+            "command"
+        ]
+        assert "project_workspace" in discovery_entries[0]["command"]
         assert str(config_file) not in discovery_entries[0]["command"]
 
         discover_result = subprocess.run(
@@ -222,6 +228,10 @@ class TestGuardInstallE2E:
         assert len(discovery_groups) == 1
         assert "matcher" not in discovery_groups[0]
         assert discovery_groups[0]["hooks"][0]["async"] is True
+        assert ("-SkipDiscoveryScopes" if os.name == "nt" else "--skip-discovery-scopes") in discovery_groups[0][
+            "hooks"
+        ][0]["command"]
+        assert "project_workspace" in discovery_groups[0]["hooks"][0]["command"]
         assert str(config_file) not in discovery_groups[0]["hooks"][0]["command"]
 
         discover_result = subprocess.run(

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -535,6 +535,54 @@ def test_claude_code_discoverer_discover_mcp_servers_combines_global_and_project
     project_entry = mcp_configs[project_keys[0]]
     assert isinstance(global_entry, list) and global_entry[0][0] == "global-srv"
     assert isinstance(project_entry, list) and project_entry[0][0] == "proj-srv"
+    assert global_entry[0].scope.value == "user"
+    assert project_entry[0].scope.value == "project_workspace"
+
+
+def test_claude_code_discoverer_skips_project_source_before_calling_it(tmp_path, monkeypatch):
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude.json").write_text('{"mcpServers": {"global-srv": {"command": "g"}}}')
+    discoverer = ClaudeCodeDiscoverer(
+        tmp_path,
+        skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
+    )
+    monkeypatch.setattr(
+        discoverer,
+        "_discover_project_mcp_servers",
+        lambda: pytest.fail("project discovery must not run"),
+    )
+
+    mcp_configs = discoverer.discover_mcp_servers()
+
+    entries = next(value for value in mcp_configs.values() if isinstance(value, list))
+    assert entries[0].scope is DiscoveryLocationScope.USER
+
+
+def test_discovery_scope_precedence_keeps_user_over_project_for_same_path(tmp_path, monkeypatch):
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    (tmp_path / ".claude").mkdir()
+    discoverer = ClaudeCodeDiscoverer(tmp_path)
+    shared = (tmp_path / ".claude" / "shared.json").as_posix()
+    monkeypatch.setattr(
+        discoverer,
+        "_discover_project_mcp_servers",
+        lambda: {shared: [("project", StdioServer(command="project"))]},
+    )
+    monkeypatch.setattr(
+        discoverer,
+        "_discover_global_mcp_servers",
+        lambda: {shared: [("user", StdioServer(command="user"))]},
+    )
+
+    result = discoverer.discover_mcp_servers()
+
+    assert result[shared][0].name == "user"
+    assert result[shared][0].scope is DiscoveryLocationScope.USER
 
 
 # --- ClaudeCodeDiscoverer: project skills ---
@@ -621,6 +669,10 @@ def test_claude_code_discoverer_discover_skills_combines_global_and_project(tmp_
     skills_dirs = ClaudeCodeDiscoverer(tmp_path).discover_skills()
 
     assert len(skills_dirs) == 2  # one global, one project
+    scopes = {
+        skill.name: skill.scope.value for skills in skills_dirs.values() if isinstance(skills, list) for skill in skills
+    }
+    assert scopes == {"global-skill": "user", "proj-skill": "project_workspace"}
 
 
 # --- ClaudeCodeDiscoverer: plugin MCP + skills ---
@@ -935,6 +987,7 @@ def test_claude_code_discoverer_discover_mcp_includes_plugin_servers(tmp_path):
 
     plugin_keys = [k for k in mcp_configs if k.endswith("/p/.mcp.json")]
     assert len(plugin_keys) == 1
+    assert mcp_configs[plugin_keys[0]][0].scope.value == "extension_plugin"
 
 
 def test_claude_code_discoverer_discover_skills_includes_plugin_skills(tmp_path):
@@ -949,6 +1002,7 @@ def test_claude_code_discoverer_discover_skills_includes_plugin_skills(tmp_path)
 
     plugin_keys = [k for k in skills_dirs if "/plugins/cache/" in k]
     assert len(plugin_keys) == 1
+    assert skills_dirs[plugin_keys[0]][0].scope.value == "extension_plugin"
 
 
 def test_claude_code_discoverer_plugin_mcp_servers_scans_repos_dir(tmp_path):
@@ -1239,6 +1293,15 @@ def test_find_discoverers_returns_empty_when_no_agents_installed(tmp_path):
     found = find_discoverers(tmp_path)
 
     assert found == []
+
+
+def test_find_discoverers_skips_client_probes_when_all_locations_are_excluded(tmp_path):
+    from agent_scan.agents import find_discoverers
+    from agent_scan.models import AUTOMATIC_DISCOVERY_SCOPES
+
+    (tmp_path / ".claude").mkdir()
+
+    assert find_discoverers(tmp_path, skip_discovery_scopes=AUTOMATIC_DISCOVERY_SCOPES) == []
 
 
 # --- Pipeline dispatch: legacy for all + ABC merge phase ---
@@ -4942,6 +5005,7 @@ def test_claude_code_discovers_managed_mcp_servers(tmp_path, monkeypatch):
     name, server = mcp_configs[keys[0]][0]
     assert name == "corp-server"
     assert isinstance(server, StdioServer)
+    assert mcp_configs[keys[0]][0].scope.value == "system"
 
 
 def test_managed_mcp_path_honors_program_files_env_on_windows(tmp_path, monkeypatch):
@@ -5550,6 +5614,7 @@ def test_windsurf_discovers_system_skills_dir(tmp_path, monkeypatch):
     keys = [k for k in skills_dirs if k.endswith("/system-windsurf-skills")]
     assert len(keys) == 1
     assert {skill.name for skill in skills_dirs[keys[0]]} == {"system-skill"}
+    assert {skill.scope.value for skill in skills_dirs[keys[0]]} == {"system"}
 
 
 @pytest.mark.skipif(
@@ -6982,6 +7047,7 @@ def test_codex_discoverer_discovers_system_mcp_servers(tmp_path, monkeypatch):
     keys = [k for k in mcp_configs if k.endswith("/system-config.toml")]
     assert len(keys) == 1
     assert mcp_configs[keys[0]][0][0] == "system_srv"
+    assert mcp_configs[keys[0]][0].scope.value == "system"
 
 
 def test_codex_system_config_path_is_per_os(monkeypatch):
@@ -8617,6 +8683,63 @@ def test_opencode_discoverer_scans_skills_paths_relative_against_each_worktree(t
     assert not any(k.endswith("/.config/opencode/team-skills") for k in skills_dirs)
 
 
+def test_opencode_user_config_relative_skill_survives_skipped_user_scope(tmp_path):
+    from agent_scan.agents import OpenCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    install = _opencode_install(tmp_path)
+    project = tmp_path / "project"
+    project_skill = project / "team-skills" / "project-skill"
+    project_skill.mkdir(parents=True)
+    (project_skill / "SKILL.md").write_text("---\nname: project-skill\ndescription: p\n---\nBody\n")
+    user_root = tmp_path / "user-skills"
+    user_skill = user_root / "user-skill"
+    user_skill.mkdir(parents=True)
+    (user_skill / "SKILL.md").write_text("---\nname: user-skill\ndescription: u\n---\nBody\n")
+    (install / "opencode.json").write_text(json.dumps({"skills": {"paths": ["./team-skills", "~/user-skills"]}}))
+    _seed_opencode_db(tmp_path / ".local" / "share" / "opencode" / "opencode.db", [project.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(
+        tmp_path,
+        skip_discovery_scopes={DiscoveryLocationScope.USER},
+    ).discover_skills()
+
+    project_entries = skills_dirs[(project / "team-skills").as_posix()]
+    assert [skill.name for skill in project_entries] == ["project-skill"]
+    assert {skill.scope for skill in project_entries} == {DiscoveryLocationScope.PROJECT_WORKSPACE}
+    assert user_root.as_posix() not in skills_dirs
+
+
+def test_opencode_managed_config_relative_skill_survives_skipped_system_scope(tmp_path, monkeypatch):
+    from agent_scan.agents import OpenCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    _opencode_install(tmp_path)
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setattr(OpenCodeDiscoverer, "_managed_config_dir", lambda self: managed)
+    project = tmp_path / "project"
+    project_skill = project / "team-skills" / "project-skill"
+    project_skill.mkdir(parents=True)
+    (project_skill / "SKILL.md").write_text("---\nname: project-skill\ndescription: p\n---\nBody\n")
+    system_root = tmp_path / "system-skills"
+    system_skill = system_root / "system-skill"
+    system_skill.mkdir(parents=True)
+    (system_skill / "SKILL.md").write_text("---\nname: system-skill\ndescription: s\n---\nBody\n")
+    (managed / "opencode.json").write_text(json.dumps({"skills": {"paths": ["./team-skills", system_root.as_posix()]}}))
+    _seed_opencode_db(tmp_path / ".local" / "share" / "opencode" / "opencode.db", [project.as_posix()])
+
+    skills_dirs = OpenCodeDiscoverer(
+        tmp_path,
+        skip_discovery_scopes={DiscoveryLocationScope.SYSTEM},
+    ).discover_skills()
+
+    project_entries = skills_dirs[(project / "team-skills").as_posix()]
+    assert [skill.name for skill in project_entries] == ["project-skill"]
+    assert {skill.scope for skill in project_entries} == {DiscoveryLocationScope.PROJECT_WORKSPACE}
+    assert system_root.as_posix() not in skills_dirs
+
+
 def test_opencode_discoverer_skills_paths_relative_records_nothing_without_projects(tmp_path):
     """With no opened projects there is no instance directory to anchor a relative
     ``skills.paths`` entry against, so it resolves to nothing — matching that
@@ -9234,6 +9357,36 @@ async def test_pipeline_preserves_unresolved_target_folder_spelling(tmp_path):
         )
 
     find.assert_called_once_with(home, target_folders=[project_link])
+
+
+@pytest.mark.asyncio
+async def test_pipeline_does_not_resolve_target_folders_when_project_scope_is_skipped(tmp_path):
+    from agent_scan.models import DiscoveryLocationScope
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    home = tmp_path / "home"
+    home.mkdir()
+    with (
+        patch("agent_scan.pipelines.get_readable_home_directories", return_value=[(home, "alice")]),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[]),
+        patch("agent_scan.pipelines.find_discoverers", return_value=[]) as find,
+        patch.object(Path, "resolve", side_effect=AssertionError("target folder must not be resolved")),
+    ):
+        await discover_clients_to_inspect(
+            InspectArgs(
+                timeout=0,
+                tokens=[],
+                paths=[],
+                target_folders=["/session/project"],
+                skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
+            )
+        )
+
+    find.assert_called_once_with(
+        home,
+        target_folders=[],
+        skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -9360,33 +9360,61 @@ async def test_pipeline_preserves_unresolved_target_folder_spelling(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_pipeline_does_not_resolve_target_folders_when_project_scope_is_skipped(tmp_path):
+async def test_pipeline_retains_target_scope_without_reading_excluded_project_configs(tmp_path, monkeypatch):
     from agent_scan.models import DiscoveryLocationScope
     from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
 
     home = tmp_path / "home"
-    home.mkdir()
-    with (
-        patch("agent_scan.pipelines.get_readable_home_directories", return_value=[(home, "alice")]),
-        patch("agent_scan.pipelines.get_well_known_clients", return_value=[]),
-        patch("agent_scan.pipelines.find_discoverers", return_value=[]) as find,
-        patch.object(Path, "resolve", side_effect=AssertionError("target folder must not be resolved")),
-    ):
-        await discover_clients_to_inspect(
-            InspectArgs(
-                timeout=0,
-                tokens=[],
-                paths=[],
-                target_folders=["/session/project"],
-                skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
-            )
-        )
-
-    find.assert_called_once_with(
-        home,
-        target_folders=[],
-        skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
+    project = home / "repo"
+    project.mkdir(parents=True)
+    config = project / "override.json"
+    config.write_text('{"mcp":{"project-server":{"type":"remote","url":"https://example.com/mcp"}}}')
+    (project / "opencode.json").write_text(config.read_text())
+    monkeypatch.setattr(Path, "home", lambda: home)
+    for variable in ("OPENCODE_CONFIG_DIR", "OPENCODE_DB", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"):
+        monkeypatch.delenv(variable, raising=False)
+    monkeypatch.setenv("OPENCODE_CONFIG", str(config))
+    args = InspectArgs(
+        timeout=0, tokens=[], paths=[], target_folders=[str(project)], discovery_scope=DiscoveryScope.SERVERS
     )
+
+    clients, _, _ = await discover_clients_to_inspect(args)
+    opencode = next(client for client in clients if client.name == "opencode")
+    assert opencode.mcp_configs[config.as_posix()][0].scope == DiscoveryLocationScope.PROJECT_WORKSPACE
+
+    read_text = Path.read_text
+
+    def reject_project_read(path, *args, **kwargs):
+        if path.parent == project:
+            pytest.fail(f"excluded project config was read: {path}")
+        return read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_project_read)
+    args.skip_discovery_scopes = frozenset({DiscoveryLocationScope.PROJECT_WORKSPACE})
+    clients, _, _ = await discover_clients_to_inspect(args)
+    opencode = next(client for client in clients if client.name == "opencode")
+    assert config.as_posix() not in opencode.mcp_configs
+    assert (project / "opencode.json").as_posix() not in opencode.mcp_configs
+
+
+@pytest.mark.asyncio
+async def test_pipeline_excluding_all_scopes_does_not_resolve_targets(tmp_path, monkeypatch):
+    from agent_scan.models import AUTOMATIC_DISCOVERY_SCOPES
+    from agent_scan.pipelines import InspectArgs, discover_clients_to_inspect
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(Path, "resolve", lambda *args, **kwargs: pytest.fail("excluded target was resolved"))
+    clients, unresolved, _ = await discover_clients_to_inspect(
+        InspectArgs(
+            timeout=0,
+            tokens=[],
+            paths=[],
+            target_folders=[str(tmp_path / "repo")],
+            skip_discovery_scopes=AUTOMATIC_DISCOVERY_SCOPES,
+        )
+    )
+    assert clients == []
+    assert unresolved == []
 
 
 @pytest.mark.asyncio
@@ -9829,3 +9857,168 @@ def test_candidate_client_rejects_a_scope_override_for_an_undeclared_path():
             skills_dir_paths=[],
             mcp_config_path_scopes={"~/.typo/mcp.jsonn": DiscoveryLocationScope.SYSTEM},
         )
+
+
+@pytest.mark.parametrize("source", ["vscode_settings", "vscode_workspace", "opencode"])
+@pytest.mark.parametrize("reference", ["tilde", "absolute", "relative"])
+@pytest.mark.parametrize("skipped", [None, "user", "project_workspace", "both"])
+def test_mixed_skill_references_filter_resolved_locations(tmp_path, monkeypatch, source, reference, skipped):
+    import os
+
+    from agent_scan.agents import OpenCodeDiscoverer, VSCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "home"
+    project = home / "repo"
+    user_skills = home / "custom-skills"
+    project_skills = project / "custom-skills"
+    _write_skill(user_skills, "review-user-skill")
+    _write_skill(project_skills, "review-project-skill")
+    user_ref = {
+        "tilde": "~/custom-skills",
+        "absolute": user_skills.as_posix(),
+        "relative": "../custom-skills",
+    }[reference]
+    excluded = (
+        {DiscoveryLocationScope.USER, DiscoveryLocationScope.PROJECT_WORKSPACE}
+        if skipped == "both"
+        else ({DiscoveryLocationScope(skipped)} if skipped else set())
+    )
+    if source == "opencode":
+        discoverer = OpenCodeDiscoverer(home, [project], excluded)
+        (project / "opencode.json").write_text(json.dumps({"skills": {"paths": [user_ref, "custom-skills"]}}))
+    else:
+        discoverer = VSCodeDiscoverer(home, [project], excluded)
+        settings = {"chat.agentSkillsLocations": {user_ref: True, "custom-skills": True}}
+        if source == "vscode_settings":
+            (project / ".vscode").mkdir()
+            (project / ".vscode" / "settings.json").write_text(json.dumps(settings))
+        else:
+            workspace = project / "example.code-workspace"
+            workspace.write_text(json.dumps({"folders": [{"path": "."}], "settings": settings}))
+            storage = _userdata(discoverer) / "User" / "workspaceStorage" / "review"
+            storage.mkdir(parents=True)
+            (storage / "workspace.json").write_text(json.dumps({"workspace": workspace.as_uri()}))
+
+    listdir = os.listdir
+    excluded_dirs = {
+        directory
+        for directory, scope in (
+            (user_skills, DiscoveryLocationScope.USER),
+            (project_skills, DiscoveryLocationScope.PROJECT_WORKSPACE),
+        )
+        if scope in excluded
+    }
+
+    def reject_excluded_walk(path):
+        if Path(os.path.normpath(path)) in excluded_dirs:
+            pytest.fail(f"excluded skills directory was scanned: {path}")
+        return listdir(path)
+
+    monkeypatch.setattr(os, "listdir", reject_excluded_walk)
+    results = discoverer.discover_skills()
+    found = {
+        skill.name: skill.scope
+        for entries in results.values()
+        if isinstance(entries, list)
+        for skill in entries
+        if skill.name.startswith("review-")
+    }
+    expected = {
+        name: scope
+        for name, scope in (
+            ("review-user-skill", DiscoveryLocationScope.USER),
+            ("review-project-skill", DiscoveryLocationScope.PROJECT_WORKSPACE),
+        )
+        if scope not in excluded
+    }
+    assert found == expected
+
+
+@pytest.mark.parametrize("skipped", [None, "user", "project_workspace"])
+def test_external_registered_workspace_retains_mcp_scope_only_for_its_file(tmp_path, skipped):
+    from agent_scan.agents import VSCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "home"
+    project = home / "repo"
+    project.mkdir(parents=True)
+    workspace = home / "workspaces" / "example.code-workspace"
+    neighbouring_skills = workspace.parent / "custom-skills"
+    _write_skill(neighbouring_skills, "neighbour")
+    workspace.write_text(
+        json.dumps(
+            {
+                "folders": [{"path": project.as_posix()}],
+                "settings": {
+                    "mcp": {"servers": {"workspace-server": {"url": "https://example.com/mcp"}}},
+                    "chat.agentSkillsLocations": {"custom-skills": True},
+                },
+            }
+        )
+    )
+    discoverer = VSCodeDiscoverer(home, skip_discovery_scopes={skipped} if skipped else set())
+    storage = _userdata(discoverer) / "User" / "workspaceStorage" / "review"
+    storage.mkdir(parents=True)
+    (workspace.parent / "nested").mkdir()
+    registered = workspace.parent / "nested" / ".." / workspace.name
+    (storage / "workspace.json").write_text(json.dumps({"workspace": registered.as_uri()}))
+
+    servers = discoverer.discover_mcp_servers()
+    found = [
+        entry
+        for entries in servers.values()
+        if isinstance(entries, list)
+        for entry in entries
+        if entry.name == "workspace-server"
+    ]
+    if skipped == "project_workspace":
+        assert found == []
+    else:
+        assert len(found) == 1
+        assert found[0].scope == DiscoveryLocationScope.PROJECT_WORKSPACE
+    skills = discoverer.discover_skills()
+    neighbours = [
+        skill
+        for entries in skills.values()
+        if isinstance(entries, list)
+        for skill in entries
+        if skill.name == "neighbour"
+    ]
+    if skipped == "user":
+        assert neighbours == []
+    else:
+        assert len(neighbours) == 1
+        assert neighbours[0].scope == DiscoveryLocationScope.USER
+
+
+@pytest.mark.parametrize("location", ["home", "project"])
+@pytest.mark.parametrize("malformed", [False, True])
+def test_claude_ancestor_config_exclusion_applies_to_errors_and_guard_payload(tmp_path, location, malformed):
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.guard import _servers_discovered_entries
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "home"
+    project = home / "repo"
+    _seed_claude_home_with_project(home, project)
+    config = (home if location == "home" else project) / ".mcp.json"
+    config.write_text("{broken" if malformed else '{"mcpServers":{"review-server":{"url":"https://example.com/mcp"}}}')
+
+    client = ClaudeCodeDiscoverer(home, skip_discovery_scopes={DiscoveryLocationScope.USER}).discover(
+        DiscoveryScope.SERVERS
+    )
+    assert client is not None
+    payload = _servers_discovered_entries([client])[0]
+    if location == "home":
+        assert config.as_posix() not in client.mcp_configs
+        assert not payload.get("error")
+        assert not any(server["name"] == "review-server" for server in payload["servers"])
+    elif malformed:
+        assert isinstance(client.mcp_configs[config.as_posix()], CouldNotParseMCPConfig)
+        assert payload["error"]["category"] == "parse_error"
+        assert payload["error"]["is_failure"]
+    else:
+        assert client.mcp_configs[config.as_posix()][0].scope == DiscoveryLocationScope.PROJECT_WORKSPACE
+        assert not payload.get("error")
+        assert payload["servers"][0]["scope"] == "project_workspace"

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -9750,3 +9750,82 @@ def test_skill_merge_result_does_not_depend_on_merge_call_order(tmp_path):
     key = shared.as_posix()
     assert key in result, "a colliding path must not be dropped by the losing merge"
     assert {s.scope for s in result[key]} == {DiscoveryLocationScope.SYSTEM}
+
+
+def test_find_discoverers_tolerates_an_unknown_scope_value(tmp_path):
+    """The constructor coerces scopes to the enum and raises on an unknown
+    value, but it sat outside the try that guards client_exists() -- so the
+    ValueError escaped find_discoverers and took out discovery for the whole
+    machine, contradicting its own docstring. Under `guard discover` it is
+    swallowed whole and the hook reports nothing.
+    """
+    from agent_scan.agents import find_discoverers
+
+    assert find_discoverers(tmp_path, [], {"users"}) == []
+
+
+def test_find_discoverers_tolerates_a_bare_string_scope(tmp_path):
+    """``frozenset("user")`` iterates characters, so a caller passing a bare
+    string instead of a set raises on the first character."""
+    from agent_scan.agents import find_discoverers
+
+    assert find_discoverers(tmp_path, [], "user") == []
+
+
+def test_windows_client_merge_keeps_entries_that_differ_only_in_scope():
+    """The WSL merge dedupes on (name, exists, mcp_paths, skills_paths), a key
+    that omits both glob lists and all five scope dicts -- so a path-identical
+    but scope-divergent Linux entry silently collapses into its Windows twin.
+    Nothing covered this function at all.
+    """
+    from agent_scan.models import CandidateClient, DiscoveryLocationScope
+    from agent_scan.well_known_clients import merge_platform_clients
+
+    windows = CandidateClient(
+        name="dup",
+        client_exists_paths=["~/.dup"],
+        mcp_config_paths=["~/.dup/mcp.json"],
+        skills_dir_paths=[],
+    )
+    linux = CandidateClient(
+        name="dup",
+        client_exists_paths=["~/.dup"],
+        mcp_config_paths=["~/.dup/mcp.json"],
+        skills_dir_paths=[],
+        mcp_config_path_scopes={"~/.dup/mcp.json": DiscoveryLocationScope.SYSTEM},
+    )
+
+    merged = merge_platform_clients([windows], [linux])
+
+    assert len(merged) == 2, "entries differing only in scope must not be deduped"
+
+
+def test_windows_client_merge_still_dedupes_identical_entries():
+    from agent_scan.models import CandidateClient
+    from agent_scan.well_known_clients import merge_platform_clients
+
+    entry = CandidateClient(
+        name="same",
+        client_exists_paths=["~/.same"],
+        mcp_config_paths=["~/.same/mcp.json"],
+        skills_dir_paths=[],
+    )
+
+    assert len(merge_platform_clients([entry], [entry.model_copy()])) == 1
+
+
+def test_candidate_client_rejects_a_scope_override_for_an_undeclared_path():
+    """The override dicts are keyed by the raw declaration string, so a typo is
+    a silent no-op that degrades to default_location_scope (= user)."""
+    import pytest as _pytest
+
+    from agent_scan.models import CandidateClient, DiscoveryLocationScope
+
+    with _pytest.raises(ValueError, match="mcp_config_path_scopes"):
+        CandidateClient(
+            name="typo",
+            client_exists_paths=["~/.typo"],
+            mcp_config_paths=["~/.typo/mcp.json"],
+            skills_dir_paths=[],
+            mcp_config_path_scopes={"~/.typo/mcp.jsonn": DiscoveryLocationScope.SYSTEM},
+        )

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -9519,3 +9519,234 @@ async def test_pipeline_null_byte_target_folder_is_skipped_without_aborting(tmp_
         )
 
     find.assert_called_once_with(home, target_folders=[good])
+
+
+# --- location scope must follow where a component lives, not who declared it ---
+
+
+def _seed_claude_home_with_project(home: Path, project: Path) -> None:
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    project.mkdir(parents=True, exist_ok=True)
+    (home / ".claude.json").write_text(f'{{"projects": {{"{project.as_posix()}": {{"mcpServers": {{}}}}}}}}')
+
+
+def test_user_skills_dir_is_not_relabelled_project_when_user_scope_is_skipped(tmp_path):
+    """``$HOME`` is an ancestor of any project beneath it, so the project-scope
+    sweep re-finds ``~/.claude/skills``. Labelling that copy ``project_workspace``
+    makes ``--skip-discovery-scopes user`` a no-op: the directory is still
+    scanned and still reported, just under the other label."""
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "user"
+    _seed_claude_home_with_project(home, home / "proj")
+    skill = home / ".claude" / "skills" / "myskill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: myskill\ndescription: d\n---\nBody\n")
+
+    unfiltered = ClaudeCodeDiscoverer(home).discover_skills()
+    user_key = (home / ".claude" / "skills").as_posix()
+    assert {s.scope for s in unfiltered[user_key]} == {DiscoveryLocationScope.USER}
+
+    filtered = ClaudeCodeDiscoverer(home, skip_discovery_scopes={DiscoveryLocationScope.USER}).discover_skills()
+    assert user_key not in filtered
+
+
+def test_monorepo_ancestor_skills_stay_project_scoped(tmp_path):
+    """Guard against over-demotion: the ancestor walk exists so a monorepo root
+    above the opened project is still project config."""
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "user"
+    _seed_claude_home_with_project(home, tmp_path / "work" / "mono" / "app")
+    ancestor_skills = tmp_path / "work" / "mono" / ".claude" / "skills" / "shared"
+    ancestor_skills.mkdir(parents=True)
+    (ancestor_skills / "SKILL.md").write_text("---\nname: shared\ndescription: d\n---\nBody\n")
+
+    skills_dirs = ClaudeCodeDiscoverer(home).discover_skills()
+
+    key = (tmp_path / "work" / "mono" / ".claude" / "skills").as_posix()
+    assert {s.scope for s in skills_dirs[key]} == {DiscoveryLocationScope.PROJECT_WORKSPACE}
+
+
+def test_repo_settings_cannot_label_a_home_directory_project_scoped(tmp_path, monkeypatch):
+    """A repo-committed ``.vscode/settings.json`` picks the path *and* the label.
+    If the declaring file decides the scope, a committed config can point at the
+    user's home and choose the label that excludes it from the scan."""
+    from agent_scan.agents.vscode import VSCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "user"
+    rogue = home / ".local" / "share" / "rogue-skills" / "evil"
+    rogue.mkdir(parents=True)
+    (rogue / "SKILL.md").write_text("---\nname: evil\ndescription: d\n---\nBody\n")
+
+    repo = tmp_path / "work" / "repo"
+    vscode_dir = repo / ".vscode"
+    vscode_dir.mkdir(parents=True)
+    locations = {(home / ".local" / "share" / "rogue-skills").as_posix(): True}
+    (vscode_dir / "settings.json").write_text(json.dumps({"chat.agentSkillsLocations": locations}))
+
+    key = (home / ".local" / "share" / "rogue-skills").as_posix()
+    discoverer = VSCodeDiscoverer(home, [repo])
+    scoped = discoverer._discover_settings_skill_locations(include_user=False, include_project=True)
+    assert key in scoped
+
+    labelled = VSCodeDiscoverer(home, [repo]).discover_skills()
+    assert {s.scope for s in labelled[key]} == {DiscoveryLocationScope.USER}
+
+
+def test_opencode_absolute_skills_path_entry_is_platform_independent():
+    """``Path`` is platform-bound, so a machine-wide POSIX path in a config read
+    on Windows looks relative and gets joined onto every worktree -- escaping it.
+    A Windows drive path read on Linux is misclassified the same way."""
+    from agent_scan.agents.opencode import _is_rooted_skills_entry
+
+    assert _is_rooted_skills_entry("/opt/skills")
+    assert _is_rooted_skills_entry("\\opt\\skills")
+    assert _is_rooted_skills_entry("C:/repo/skills")
+    assert _is_rooted_skills_entry("\\\\server\\share\\skills")
+    assert not _is_rooted_skills_entry("rel/skills")
+    assert not _is_rooted_skills_entry("~/skills")
+    assert not _is_rooted_skills_entry("~\\skills")
+    assert not _is_rooted_skills_entry("~")
+
+
+def test_opencode_windows_home_spelling_resolves_to_home(tmp_path):
+    """``~\\skills`` is the Windows spelling of a home path; treating it as
+    project-relative resolves it to a literal ``~`` directory inside the repo."""
+    from agent_scan.agents.opencode import OpenCodeDiscoverer
+
+    discoverer = OpenCodeDiscoverer(tmp_path)
+
+    assert discoverer._resolve_skills_path_entry("~\\skills", [tmp_path / "repo"]) == [tmp_path / "skills"]
+
+
+def test_opencode_env_override_config_scope_follows_its_location(tmp_path, monkeypatch):
+    """``$OPENCODE_CONFIG`` can point anywhere, so a fixed ``user`` label is
+    wrong in both directions: a project-local override survives
+    ``--skip-discovery-scopes project_workspace``, and a relocated global config
+    is dropped entirely by ``--skip-discovery-scopes user`` without any error."""
+    from agent_scan.agents.opencode import OpenCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "user"
+    (home / ".config" / "opencode").mkdir(parents=True)
+    _force_home(monkeypatch, home)
+
+    repo = tmp_path / "work" / "repo"
+    repo.mkdir(parents=True)
+    project_config = repo / "relocated.json"
+    project_config.write_text('{"mcp": {"proj-srv": {"type": "local", "command": ["node"]}}}')
+    monkeypatch.setenv("OPENCODE_CONFIG", str(project_config))
+
+    discoverer = OpenCodeDiscoverer(home, [repo])
+    entries = discoverer.discover_mcp_servers()[project_config.as_posix()]
+    assert {e.scope for e in entries} == {DiscoveryLocationScope.PROJECT_WORKSPACE}
+
+    skipped = OpenCodeDiscoverer(
+        home, [repo], skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE}
+    ).discover_mcp_servers()
+    assert project_config.as_posix() not in skipped
+
+
+def test_opencode_env_override_outside_any_project_is_user_scoped(tmp_path, monkeypatch):
+    from agent_scan.agents.opencode import OpenCodeDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "user"
+    (home / ".config" / "opencode").mkdir(parents=True)
+    _force_home(monkeypatch, home)
+
+    elsewhere = tmp_path / "elsewhere" / "opencode.json"
+    elsewhere.parent.mkdir(parents=True)
+    elsewhere.write_text('{"mcp": {"relocated": {"type": "local", "command": ["node"]}}}')
+    monkeypatch.setenv("OPENCODE_CONFIG", str(elsewhere))
+
+    entries = OpenCodeDiscoverer(home).discover_mcp_servers()[elsewhere.as_posix()]
+
+    assert {e.scope for e in entries} == {DiscoveryLocationScope.USER}
+
+
+def test_merge_keeps_a_surfaced_parse_failure_over_a_later_empty_result(tmp_path):
+    """``_result_precedence`` scored errors and empty lists identically, so a
+    later pass that merely found nothing at the same path erased a parse failure
+    the scanner deliberately reports. opencode hits this for real: a malformed
+    ``$OPENCODE_CONFIG`` is surfaced on purpose, then merged at ``user`` after
+    the project pass and before the system one."""
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import CouldNotParseMCPConfig, DiscoveryLocationScope
+
+    discoverer = ClaudeCodeDiscoverer(tmp_path)
+    error = CouldNotParseMCPConfig(message="could not parse", traceback="tb", is_failure=True)
+    target = {"/p/config.json": error}
+
+    discoverer._merge_mcp_results(target, lambda: {"/p/config.json": []}, DiscoveryLocationScope.SYSTEM)
+
+    assert target["/p/config.json"] is error
+
+
+def test_merge_lets_real_data_replace_a_parse_failure(tmp_path):
+    """Real servers are still more informative than an error at the same path."""
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import CouldNotParseMCPConfig, DiscoveryLocationScope, StdioServer
+
+    discoverer = ClaudeCodeDiscoverer(tmp_path)
+    target = {"/p/config.json": CouldNotParseMCPConfig(message="x", traceback="tb", is_failure=True)}
+
+    discoverer._merge_mcp_results(
+        target,
+        lambda: {"/p/config.json": [("srv", StdioServer(command="node"))]},
+        DiscoveryLocationScope.SYSTEM,
+    )
+
+    entries = target["/p/config.json"]
+    assert isinstance(entries, list)
+    assert entries[0].name == "srv"
+
+
+def test_merge_keeps_a_parse_failure_over_a_file_not_found(tmp_path):
+    """A deliberate failure outranks a benign "not present" record."""
+    from agent_scan.agents import ClaudeCodeDiscoverer
+    from agent_scan.models import CouldNotParseMCPConfig, DiscoveryLocationScope, FileNotFoundConfig
+
+    discoverer = ClaudeCodeDiscoverer(tmp_path)
+    error = CouldNotParseMCPConfig(message="x", traceback="tb", is_failure=True)
+    target = {"/p/config.json": error}
+
+    discoverer._merge_mcp_results(
+        target,
+        lambda: {"/p/config.json": FileNotFoundConfig(message="missing", is_failure=False)},
+        DiscoveryLocationScope.SYSTEM,
+    )
+
+    assert target["/p/config.json"] is error
+
+
+def test_skill_merge_result_does_not_depend_on_merge_call_order(tmp_path):
+    """``_merge_*`` compares precedence rather than overwriting blindly, so a
+    subclass that merges a lower tier after a higher one (Cursor appends its
+    USER and EXTENSION_PLUGIN sources after ``super()`` has already merged
+    SYSTEM) still resolves to the owning tier instead of to whichever call ran
+    last. Pinned because the ordering is otherwise an invisible constraint on
+    every subclass.
+    """
+    from agent_scan.agents.vscode.cursor import CursorDiscoverer
+    from agent_scan.models import DiscoveryLocationScope
+
+    home = tmp_path / "user"
+    (home / ".cursor").mkdir(parents=True)
+    shared = home / "shared-skills"
+    (shared / "sk").mkdir(parents=True)
+    (shared / "sk" / "SKILL.md").write_text("---\nname: sk\ndescription: d\n---\nBody\n")
+
+    discoverer = CursorDiscoverer(home)
+    discoverer._platform_system_skills_dirs = lambda: [shared]
+    discoverer._builtin_skills_dirs = lambda: [shared]
+
+    result = discoverer.discover_skills()
+
+    key = shared.as_posix()
+    assert key in result, "a colliding path must not be dropped by the losing merge"
+    assert {s.scope for s in result[key]} == {DiscoveryLocationScope.SYSTEM}

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -547,7 +547,7 @@ def test_claude_code_discoverer_skips_project_source_before_calling_it(tmp_path,
     (tmp_path / ".claude.json").write_text('{"mcpServers": {"global-srv": {"command": "g"}}}')
     discoverer = ClaudeCodeDiscoverer(
         tmp_path,
-        skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
+        skip_discovery_scopes=frozenset({DiscoveryLocationScope.PROJECT_WORKSPACE}),
     )
     monkeypatch.setattr(
         discoverer,
@@ -9356,7 +9356,7 @@ async def test_pipeline_preserves_unresolved_target_folder_spelling(tmp_path):
             InspectArgs(timeout=0, tokens=[], paths=[], target_folders=[str(project_link)])
         )
 
-    find.assert_called_once_with(home, target_folders=[project_link])
+    find.assert_called_once_with(home, target_folders=[project_link], skip_discovery_scopes=frozenset())
 
 
 @pytest.mark.asyncio
@@ -9437,7 +9437,7 @@ async def test_pipeline_skips_target_folder_when_exists_raises(tmp_path, caplog)
             InspectArgs(timeout=0, tokens=[], paths=[], target_folders=[str(stale), str(good)])
         )
 
-    find.assert_called_once_with(home, target_folders=[good])
+    find.assert_called_once_with(home, target_folders=[good], skip_discovery_scopes=frozenset())
     assert str(stale) in caplog.text
     assert "Skipping" in caplog.text
 
@@ -9491,7 +9491,7 @@ async def test_pipeline_runtime_error_resolving_target_keeps_literal_folder(tmp_
             InspectArgs(timeout=0, tokens=[], paths=[], target_folders=[target.as_posix()])
         )
 
-    find.assert_called_once_with(home, target_folders=[target])
+    find.assert_called_once_with(home, target_folders=[target], skip_discovery_scopes=frozenset())
 
 
 @pytest.mark.asyncio
@@ -9518,7 +9518,7 @@ async def test_pipeline_null_byte_target_folder_is_skipped_without_aborting(tmp_
             InspectArgs(timeout=0, tokens=[], paths=[], target_folders=["a\x00b", good.as_posix()])
         )
 
-    find.assert_called_once_with(home, target_folders=[good])
+    find.assert_called_once_with(home, target_folders=[good], skip_discovery_scopes=frozenset())
 
 
 # --- location scope must follow where a component lives, not who declared it ---

--- a/tests/unit/test_config_scan.py
+++ b/tests/unit/test_config_scan.py
@@ -499,3 +499,67 @@ class TestPluginMCPConfigFile:
         new_servers = {"replaced": StdioServer(command="node", args=["index.js"])}
         config.set_servers(new_servers)
         assert config.get_servers() == new_servers
+
+
+class TestClaudeCodeConfigOrigins:
+    """``~/.claude.json`` carries user-global servers under a top-level
+    ``mcpServers`` key *and* project-scoped servers under ``projects.<path>``.
+    Both must survive parsing, and each must stay attributable to its origin so
+    the caller can label it with the right location scope."""
+
+    @pytest.mark.asyncio
+    async def test_keeps_top_level_and_project_servers(self, tmp_path):
+        from agent_scan.models import ClaudeCodeConfigFile
+
+        config = tmp_path / ".claude.json"
+        config.write_text(
+            '{"mcpServers": {"user-global": {"command": "/bin/user"}},'
+            ' "projects": {"/work/repo": {"mcpServers": {"proj": {"command": "/bin/proj"}}}}}'
+        )
+
+        mcp_config = await scan_mcp_config_file(str(config))
+
+        assert isinstance(mcp_config, ClaudeCodeConfigFile)
+        servers = mcp_config.get_servers()
+        assert set(servers) == {"user-global", "proj"}
+
+    @pytest.mark.asyncio
+    async def test_groups_servers_by_declaring_origin(self, tmp_path):
+        config = tmp_path / ".claude.json"
+        config.write_text(
+            '{"mcpServers": {"user-global": {"command": "/bin/user"}},'
+            ' "projects": {"/work/repo": {"mcpServers": {"proj": {"command": "/bin/proj"}}}}}'
+        )
+
+        mcp_config = await scan_mcp_config_file(str(config))
+        origins = mcp_config.get_servers_by_origin()
+
+        assert set(origins) == {None, "/work/repo"}
+        assert set(origins[None]) == {"user-global"}
+        assert set(origins["/work/repo"]) == {"proj"}
+
+    @pytest.mark.asyncio
+    async def test_same_named_server_in_two_projects_stays_distinct(self, tmp_path):
+        """The same ``github`` server configured in two repos is two registrations
+        with different commands; flattening by name silently drops one."""
+        config = tmp_path / ".claude.json"
+        config.write_text(
+            '{"projects": {"/work/a": {"mcpServers": {"github": {"command": "/bin/a"}}},'
+            ' "/work/b": {"mcpServers": {"github": {"command": "/bin/b"}}}}}'
+        )
+
+        mcp_config = await scan_mcp_config_file(str(config))
+        origins = mcp_config.get_servers_by_origin()
+
+        assert set(origins) == {"/work/a", "/work/b"}
+        assert origins["/work/a"]["github"].command == "/bin/a"
+        assert origins["/work/b"]["github"].command == "/bin/b"
+
+    @pytest.mark.asyncio
+    async def test_project_only_config_reports_no_user_origin(self, tmp_path):
+        config = tmp_path / ".claude.json"
+        config.write_text('{"projects": {"/work/repo": {"mcpServers": {"proj": {"command": "/bin/proj"}}}}}')
+
+        origins = (await scan_mcp_config_file(str(config))).get_servers_by_origin()
+
+        assert set(origins) == {"/work/repo"}

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import json
 import os
 import shutil
@@ -251,14 +252,15 @@ class TestExtractEnvFromCmd:
             False,
             "PUSH_KEY='pk' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' MACHINE_ID='machine' "
             "AGENT_SCAN_COMMAND='/usr/local/bin/snyk-agent-scan' bash '/x/snyk-agent-guard-discover.sh' "
-            "--client 'claude-code' --scope servers",
+            "--client 'claude-code' --scope servers --skip-discovery-scopes project_workspace",
         ),
         (
             "discover",
             True,
             "powershell -File 'C:\\hooks\\snyk-agent-guard-discover.ps1' -Client claude-code -PushKey 'pk' "
             "-RemoteUrl 'https://api.snyk.io' -MachineId 'machine' "
-            "-AgentScanCommand 'C:\\Program Files\\Snyk\\snyk-agent-scan.exe' -Scope servers",
+            "-AgentScanCommand 'C:\\Program Files\\Snyk\\snyk-agent-scan.exe' -Scope servers "
+            "-SkipDiscoveryScopes project_workspace",
         ),
     ],
 )
@@ -469,7 +471,10 @@ class TestBuildDiscoverHookCommand:
         assert "TENANT_ID=" not in command
         assert "MACHINE_ID='machine'" in command
         assert "AGENT_SCAN_COMMAND='/opt/Snyk'\"'\"'s bin/snyk-agent-scan'" in command
-        assert command.endswith(f"bash '/x/snyk-agent-guard-discover.sh' --client '{client}' --scope servers")
+        assert command.endswith(
+            f"bash '/x/snyk-agent-guard-discover.sh' --client '{client}' --scope servers "
+            "--skip-discovery-scopes project_workspace"
+        )
         assert _is_agent_scan_command(command)
 
     @pytest.mark.parametrize("client", ["claude-code", "cursor", "codex"])
@@ -488,7 +493,8 @@ class TestBuildDiscoverHookCommand:
         assert command == (
             rf"powershell -File 'C:\hooks\snyk-agent-guard-discover.ps1' -Client {client} "
             "-PushKey 'pk' -RemoteUrl 'https://api.snyk.io' -MachineId 'machine''s-id' "
-            r"-AgentScanCommand 'C:\Program Files\Snyk\snyk-agent-scan.exe' -Scope servers"
+            r"-AgentScanCommand 'C:\Program Files\Snyk\snyk-agent-scan.exe' -Scope servers "
+            r"-SkipDiscoveryScopes project_workspace"
         )
 
     def test_powershell_escapes_single_quotes_in_paths(self):
@@ -587,6 +593,7 @@ class TestHookInvocationRenderers:
             tenant_id="tenant",
             agent_scan_command="/opt/Snyk's bin/snyk-agent-scan",
             scope="servers",
+            skip_discovery_scopes="project_workspace",
             quote_client=True,
         )
 
@@ -600,6 +607,8 @@ class TestHookInvocationRenderers:
             "cursor",
             "--scope",
             "servers",
+            "--skip-discovery-scopes",
+            "project_workspace",
         ]
         assert env == {
             "EXISTING": "value",
@@ -620,6 +629,7 @@ class TestHookInvocationRenderers:
             tenant_id="tenant",
             agent_scan_command=r"C:\Program Files\Snyk\snyk-agent-scan.exe",
             scope="servers",
+            skip_discovery_scopes="project_workspace",
         )
 
         with patch(f"{_G}.IS_WINDOWS", True):
@@ -641,6 +651,8 @@ class TestHookInvocationRenderers:
             r"C:\Program Files\Snyk\snyk-agent-scan.exe",
             "-Scope",
             "servers",
+            "-SkipDiscoveryScopes",
+            "project_workspace",
         ]
         assert env is None
 
@@ -4352,6 +4364,25 @@ class TestServersDiscoveredPayload:
         assert [server["name"] for server in result[0]["servers"]] == ["good"]
         assert result[0]["error"]["category"] == "parse_error"
 
+    def test_preserves_discovered_server_location_scope(self):
+        from agent_scan.models import DiscoveredServer, DiscoveryLocationScope
+
+        client = self._client(
+            mcp_configs={
+                "/config.json": [
+                    DiscoveredServer(
+                        name="github",
+                        server=StdioServer(command="github"),
+                        scope=DiscoveryLocationScope.EXTENSION_PLUGIN,
+                    )
+                ]
+            }
+        )
+
+        result = guard_module._servers_discovered_entries([client])
+
+        assert result[0]["servers"][0]["scope"] == "extension_plugin"
+
     def test_client_with_only_error_configs_still_emits_entry(self):
         client = self._client(
             mcp_configs={
@@ -4390,7 +4421,7 @@ class TestServersDiscoveredPayload:
     def test_empty_input_returns_empty_list(self):
         assert guard_module._servers_discovered_entries([]) == []
 
-    def test_matches_scan_path_request_wire_shape(self):
+    def test_adds_scope_only_to_guard_server_entries(self):
         from agent_scan.verify_api import build_scan_request
 
         server = StdioServer(command="npx", args=["--mode", "read-only"], binary_identifier="binary-id")
@@ -4403,10 +4434,20 @@ class TestServersDiscoveredPayload:
 
         result = guard_module._servers_discovered_entries([client])
 
-        expected = build_scan_request([inspected]).scan_path_requests[0].model_dump(mode="json")
+        analysis_request = build_scan_request([inspected]).scan_path_requests[0].model_dump(mode="json")
+        expected = copy.deepcopy(analysis_request)
+        expected["servers"][0]["scope"] = "custom"
         assert result == [expected]
+        assert "scope" not in analysis_request["servers"][0]
         assert set(result[0]) == {"client", "path", "servers", "skills", "error"}
-        assert set(result[0]["servers"][0]) == {"name", "config_path", "server", "signature", "error"}
+        assert set(result[0]["servers"][0]) == {
+            "name",
+            "config_path",
+            "server",
+            "signature",
+            "error",
+            "scope",
+        }
         assert result[0]["servers"][0]["server"] == {
             "command": "npx",
             "args": ["--mode", "read-only"],
@@ -4467,6 +4508,17 @@ class TestDiscoverServersPayload:
             guard_module._discover_servers_payload(discovery_scope=DiscoveryScope.SERVERS)
 
         assert discover.await_args.args[0].discovery_scope is DiscoveryScope.SERVERS
+
+    def test_forwards_location_scope_exclusions(self):
+        from agent_scan.models import DiscoveryLocationScope
+
+        discover = AsyncMock(return_value=([], [], []))
+        skipped = {DiscoveryLocationScope.PROJECT_WORKSPACE}
+
+        with patch("agent_scan.pipelines.discover_clients_to_inspect", discover):
+            guard_module._discover_servers_payload(skip_discovery_scopes=skipped)
+
+        assert discover.await_args.args[0].skip_discovery_scopes == skipped
 
     def test_threads_target_folders_to_inspect_args(self):
         discover = AsyncMock(return_value=([], [], []))
@@ -4833,6 +4885,102 @@ class TestGuardDiscoverCli:
         assert exc.value.code == 0
         assert run.call_args.args[0].client == agent
 
+    def test_discovery_scope_exclusions_default_to_empty(self, monkeypatch):
+        from agent_scan import cli
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["agent-scan", "guard", "discover", "--client", "claude-code"],
+        )
+        with patch(f"{_G}.run_guard", return_value=0) as run, pytest.raises(SystemExit):
+            cli.main()
+
+        assert run.call_args.args[0].skip_discovery_scopes == frozenset()
+
+    def test_parses_discovery_scope_exclusion_csv(self, monkeypatch):
+        from agent_scan import cli
+        from agent_scan.models import DiscoveryLocationScope
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "agent-scan",
+                "guard",
+                "discover",
+                "--client",
+                "claude-code",
+                "--skip-discovery-scopes",
+                " user,project_workspace,user ",
+            ],
+        )
+        with patch(f"{_G}.run_guard", return_value=0) as run, pytest.raises(SystemExit):
+            cli.main()
+
+        assert run.call_args.args[0].skip_discovery_scopes == frozenset(
+            {DiscoveryLocationScope.USER, DiscoveryLocationScope.PROJECT_WORKSPACE}
+        )
+
+    def test_parses_all_discovery_scope_exclusions(self, monkeypatch):
+        from agent_scan import cli
+        from agent_scan.models import AUTOMATIC_DISCOVERY_SCOPES
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "agent-scan",
+                "guard",
+                "discover",
+                "--client",
+                "claude-code",
+                "--skip-discovery-scopes",
+                "all",
+            ],
+        )
+        with patch(f"{_G}.run_guard", return_value=0) as run, pytest.raises(SystemExit):
+            cli.main()
+
+        assert run.call_args.args[0].skip_discovery_scopes == AUTOMATIC_DISCOVERY_SCOPES
+
+    @pytest.mark.parametrize("value", ["", "user,,system", "custom", "unknown", "all,user"])
+    def test_rejects_invalid_discovery_scope_exclusions(self, value, monkeypatch):
+        from agent_scan import cli
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "agent-scan",
+                "guard",
+                "discover",
+                "--client",
+                "claude-code",
+                "--skip-discovery-scopes",
+                value,
+            ],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 2
+
+    def test_location_scope_exclusion_flag_is_not_available_to_scan(self, monkeypatch):
+        from agent_scan import cli
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["agent-scan", "scan", "--skip-discovery-scopes", "user"],
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+        assert exc.value.code == 2
+
 
 class TestRunDiscover:
     @pytest.fixture(autouse=True)
@@ -4888,6 +5036,26 @@ class TestRunDiscover:
         assert captured["client"] == "claude-code"
         assert captured["push_key"] == "env-pk"
         assert captured["machine_id"] == "env-machine"
+
+    def test_forwards_requested_location_scope_exclusions(self, tmp_path, monkeypatch):
+        from agent_scan.models import DiscoveryLocationScope
+
+        monkeypatch.setenv("PUSH_KEY", "env-pk")
+        skipped = frozenset({DiscoveryLocationScope.PROJECT_WORKSPACE})
+        discover = MagicMock(return_value=[])
+        with (
+            patch(f"{_G}._discover_servers_payload", discover),
+            patch(f"{_G}.send_hook_event", return_value=(True, "")),
+            patch(f"{_G}.rich"),
+        ):
+            result = guard_module.run_guard(self._args(tmp_path / "settings.json", skip_discovery_scopes=skipped))
+
+        assert result == 0
+        discover.assert_called_once_with(
+            [],
+            discovery_scope="all",
+            skip_discovery_scopes=skipped,
+        )
 
     def test_explicit_url_overrides_environment(self, tmp_path, monkeypatch):
         config = tmp_path / "settings.json"

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -63,7 +63,15 @@ from agent_scan.guard import (
     _write_codex_managed_config,
     _write_config,
 )
-from agent_scan.models import ClientToInspect, InspectedPath, InspectedServer, RemoteServer, StdioServer
+from agent_scan.models import (
+    ClientToInspect,
+    DiscoveredServer,
+    DiscoveryLocationScope,
+    InspectedPath,
+    InspectedServer,
+    RemoteServer,
+    StdioServer,
+)
 from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig
 from agent_scan.pushkeys import GuardEnabledAccessDeniedError
 
@@ -6373,3 +6381,71 @@ class TestRunInstallSkipsUninstalledClients:
         assert mock_install.call_count == len(ALL_CLIENTS)
         called_clients = [c.args[0] for c in mock_install.call_args_list]
         assert called_clients == ALL_CLIENTS
+
+
+class TestGuardDiscoveryWireModel:
+    """``scope`` reaches Guard's session-start event but must not appear on the
+    analysis wire. It was attached by mutating the already-serialized payload,
+    which bypasses the boundary ``verify_api.build_scan_request`` documents as
+    owning inspection-to-wire conversion ("The versioned API models own the
+    structural conversion")."""
+
+    def test_scope_is_carried_by_a_versioned_model_not_dict_mutation(self):
+        from agent_scan.models.api.v20260710 import GuardMcpServerRequest
+        from agent_scan.models.inspect import GuardInspectedServer
+
+        server = StdioServer(command="npx")
+        inspected = GuardInspectedServer(
+            name="github",
+            config_path="/config.json",
+            server=server,
+            scope=DiscoveryLocationScope.PROJECT_WORKSPACE,
+        )
+
+        request = GuardMcpServerRequest.from_inspected(inspected)
+
+        assert request.scope == "project_workspace"
+
+    def test_inspect_json_output_shape_is_unchanged(self):
+        """``InspectedServer`` is dumped verbatim by ``inspect --json``, so the
+        scope field lives on a Guard-side subclass instead of on it."""
+        from agent_scan.models.inspect import InspectedServer
+
+        assert "scope" not in InspectedServer.model_fields
+
+    def test_analysis_wire_still_has_no_scope_field(self):
+        """The analysis request is sent by ``analyze_machine`` under the same
+        version header, so ``scope`` must not leak onto it."""
+        from agent_scan.models.api.v20260710 import McpServerRequest
+
+        assert "scope" not in McpServerRequest.model_fields
+
+    def test_scope_survives_a_reordered_or_filtered_conversion(self):
+        """The old implementation zipped scopes onto the payload positionally
+        with ``strict=True``, so it depended on ``from_inspected`` never
+        filtering or reordering servers -- and the first version that dropped an
+        errored server would raise ValueError into a bare ``except Exception``
+        that renders as a generic warning."""
+        servers = [
+            StdioServer(command="a"),
+            StdioServer(command="b"),
+        ]
+        client = self._client(
+            mcp_configs={
+                "/a.json": [DiscoveredServer(name="a", server=servers[0], scope=DiscoveryLocationScope.SYSTEM)],
+                "/b.json": [DiscoveredServer(name="b", server=servers[1], scope=DiscoveryLocationScope.USER)],
+            }
+        )
+
+        result = guard_module._servers_discovered_entries([client])
+
+        by_name = {s["name"]: s["scope"] for s in result[0]["servers"]}
+        assert by_name == {"a": "system", "b": "user"}
+
+    def _client(self, *, mcp_configs):
+        return ClientToInspect(
+            name="claude code",
+            client_path="/home/u/.claude",
+            mcp_configs=mcp_configs,
+            skills_dirs={},
+        )

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -5140,7 +5140,7 @@ class TestRunDiscover:
 
         assert result == 0
         stdin.read.assert_called_once_with(1024 * 1024)
-        discover.assert_called_once_with(["/session/project"], discovery_scope="all")
+        discover.assert_called_once_with(["/session/project"], discovery_scope="all", skip_discovery_scopes=frozenset())
         assert json.loads(send.call_args.args[3])["session_id"] == "session"
 
     def test_hook_stdin_reads_cwd_for_codex(self, tmp_path, monkeypatch):
@@ -5162,7 +5162,7 @@ class TestRunDiscover:
 
         assert result == 0
         stdin.read.assert_called_once_with(1024 * 1024)
-        discover.assert_called_once_with(["/session/project"], discovery_scope="all")
+        discover.assert_called_once_with(["/session/project"], discovery_scope="all", skip_discovery_scopes=frozenset())
         assert json.loads(send.call_args.args[3])["session_id"] == "session"
 
     def test_hook_stdin_accepts_workspace_roots_list(self, tmp_path, monkeypatch):
@@ -5183,7 +5183,9 @@ class TestRunDiscover:
             result = guard_module.run_guard(self._args(config, client="cursor"))
 
         assert result == 0
-        discover.assert_called_once_with(["/workspace/one", "/workspace/two"], discovery_scope="all")
+        discover.assert_called_once_with(
+            ["/workspace/one", "/workspace/two"], discovery_scope="all", skip_discovery_scopes=frozenset()
+        )
         assert send.call_args.args[:3] == ("https://api.snyk.io", "cursor", "env-pk")
         assert json.loads(send.call_args.args[3])["conversation_id"] == "conversation"
 
@@ -5208,7 +5210,7 @@ class TestRunDiscover:
             )
 
         assert result == 0
-        discover.assert_called_once_with([], discovery_scope="all")
+        discover.assert_called_once_with([], discovery_scope="all", skip_discovery_scopes=frozenset())
         assert json.loads(send.call_args.args[3])["session_id"] == "session-start-server-discovery"
 
     def test_tty_stdin_is_not_read(self, tmp_path, monkeypatch):
@@ -5229,7 +5231,7 @@ class TestRunDiscover:
 
         assert result == 0
         stdin.read.assert_not_called()
-        discover.assert_called_once_with([], discovery_scope="all")
+        discover.assert_called_once_with([], discovery_scope="all", skip_discovery_scopes=frozenset())
 
     def test_pipe_that_never_closes_does_not_block_discovery(self, tmp_path, monkeypatch):
         import time as test_time

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -6,6 +6,7 @@ import base64
 import copy
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -19,6 +20,7 @@ from unittest.mock import call as mock_call
 import pytest
 
 import agent_scan.guard as guard_module
+from agent_scan import cli as cli_module
 from agent_scan.guard import (
     _PERMISSION_DENIED,
     ALL_CLIENTS,
@@ -260,15 +262,15 @@ class TestExtractEnvFromCmd:
             False,
             "PUSH_KEY='pk' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' MACHINE_ID='machine' "
             "AGENT_SCAN_COMMAND='/usr/local/bin/snyk-agent-scan' bash '/x/snyk-agent-guard-discover.sh' "
-            "--client 'claude-code' --scope servers --skip-discovery-scopes project_workspace",
+            "--client 'claude-code' --scope 'servers' --skip-discovery-scopes 'project_workspace'",
         ),
         (
             "discover",
             True,
             "powershell -File 'C:\\hooks\\snyk-agent-guard-discover.ps1' -Client claude-code -PushKey 'pk' "
             "-RemoteUrl 'https://api.snyk.io' -MachineId 'machine' "
-            "-AgentScanCommand 'C:\\Program Files\\Snyk\\snyk-agent-scan.exe' -Scope servers "
-            "-SkipDiscoveryScopes project_workspace",
+            "-AgentScanCommand 'C:\\Program Files\\Snyk\\snyk-agent-scan.exe' -Scope 'servers' "
+            "-SkipDiscoveryScopes 'project_workspace'",
         ),
     ],
 )
@@ -480,8 +482,8 @@ class TestBuildDiscoverHookCommand:
         assert "MACHINE_ID='machine'" in command
         assert "AGENT_SCAN_COMMAND='/opt/Snyk'\"'\"'s bin/snyk-agent-scan'" in command
         assert command.endswith(
-            f"bash '/x/snyk-agent-guard-discover.sh' --client '{client}' --scope servers "
-            "--skip-discovery-scopes project_workspace"
+            f"bash '/x/snyk-agent-guard-discover.sh' --client '{client}' --scope 'servers' "
+            "--skip-discovery-scopes 'project_workspace'"
         )
         assert _is_agent_scan_command(command)
 
@@ -501,8 +503,8 @@ class TestBuildDiscoverHookCommand:
         assert command == (
             rf"powershell -File 'C:\hooks\snyk-agent-guard-discover.ps1' -Client {client} "
             "-PushKey 'pk' -RemoteUrl 'https://api.snyk.io' -MachineId 'machine''s-id' "
-            r"-AgentScanCommand 'C:\Program Files\Snyk\snyk-agent-scan.exe' -Scope servers "
-            r"-SkipDiscoveryScopes project_workspace"
+            r"-AgentScanCommand 'C:\Program Files\Snyk\snyk-agent-scan.exe' -Scope 'servers' "
+            r"-SkipDiscoveryScopes 'project_workspace'"
         )
 
     def test_powershell_escapes_single_quotes_in_paths(self):
@@ -2091,7 +2093,7 @@ CODEX_AGENT_SCAN_CMD = (
 CODEX_DISCOVER_CMD = (
     "PUSH_KEY='pk-discover' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' "
     "AGENT_SCAN_COMMAND='/usr/local/bin/snyk-agent-scan' "
-    "bash '/home/u/.codex/hooks/snyk-agent-guard-discover.sh' --client codex --scope servers"
+    "bash '/home/u/.codex/hooks/snyk-agent-guard-discover.sh' --client codex --scope 'servers'"
 )
 
 
@@ -2311,7 +2313,7 @@ class TestDetectInstall:
         )
         later_discovery_command = (
             "PUSH_KEY='pk-later' REMOTE_HOOKS_BASE_URL='https://later.example' "
-            "bash '/x/snyk-agent-guard-discover.sh' --client test --scope servers"
+            "bash '/x/snyk-agent-guard-discover.sh' --client test --scope 'servers'"
         )
         path = tmp_path / "hooks.json"
         _write(
@@ -6449,3 +6451,88 @@ class TestGuardDiscoveryWireModel:
             mcp_configs=mcp_configs,
             skills_dirs={},
         )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX discovery script")
+class TestDiscoveryScopeFlagReachesTheCli:
+    """``--skip-discovery-scopes`` is documented and parsed as a CSV, but no test
+    ever put a multi-value CSV through a rendered hook command. On PowerShell a
+    bare ``system,user`` binds to an *array*, which coerces into the ``[string]``
+    parameter by joining on ``$OFS`` -- producing ``"system user"``, which the
+    CLI then rejects with exit 2 while the hook swallows the failure and exits 0.
+    """
+
+    def test_posix_hook_forwards_a_multi_value_csv_verbatim(self, tmp_path):
+        script = Path(guard_module.__file__).parent / "hooks" / "snyk-agent-guard-discover.sh"
+        marker = tmp_path / "invoked"
+        stub = tmp_path / "runner"
+        stub.write_text('#!/bin/sh\nprintf "%s\\n" "$*" > "$MARKER"\n')
+        stub.chmod(0o755)
+
+        result = subprocess.run(
+            [
+                "bash",
+                str(script),
+                "--client",
+                "claude-code",
+                "--scope",
+                "servers",
+                "--skip-discovery-scopes",
+                "system,user",
+            ],
+            input="{}",
+            text=True,
+            capture_output=True,
+            timeout=5,
+            env={
+                **os.environ,
+                "AGENT_SCAN_COMMAND": str(stub),
+                "MACHINE_ID": "machine-42",
+                "MARKER": str(marker),
+            },
+        )
+
+        assert result.returncode == 0
+        assert marker.read_text().strip().endswith("--skip-discovery-scopes system,user")
+
+    def test_cli_accepts_the_csv_the_renderers_emit(self):
+        """Whatever the renderers put on the command line has to parse."""
+        rendered = guard_module._render_posix_command(
+            guard_module._HookInvocation(
+                script_path=Path("/hooks/discover.sh"),
+                hook_client="claude-code",
+                push_key="k",
+                url="https://api.snyk.io",
+                scope="servers",
+                skip_discovery_scopes="system,user",
+            )
+        )
+
+        token = shlex.split(rendered)[shlex.split(rendered).index("--skip-discovery-scopes") + 1]
+        assert cli_module._parse_skip_discovery_scopes(token) == frozenset(
+            {DiscoveryLocationScope.SYSTEM, DiscoveryLocationScope.USER}
+        )
+
+    def test_powershell_renderer_quotes_the_csv_like_its_siblings(self):
+        rendered = guard_module._render_powershell_command(
+            guard_module._HookInvocation(
+                script_path=Path("C:/hooks/discover.ps1"),
+                hook_client="claude-code",
+                push_key="k",
+                url="https://api.snyk.io",
+                scope="servers",
+                skip_discovery_scopes="system,user",
+            )
+        )
+
+        assert "-SkipDiscoveryScopes 'system,user'" in rendered
+        assert "-Scope 'servers'" in rendered
+
+    def test_powershell_script_accepts_an_array_and_rejoins_it(self):
+        """Defence in depth for the argv path, where subprocess hands the value
+        to PowerShell unquoted because it contains no spaces."""
+        script = (Path(guard_module.__file__).parent / "hooks" / "snyk-agent-guard-discover.ps1").read_text()
+
+        assert "[string[]]$SkipDiscoveryScopes" in script
+        assert "-join ','" in script
+        assert "ValidatePattern" in script

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -20,6 +20,7 @@ from agent_scan.models import (
     ClientToInspect,
     CouldNotParseMCPConfig,
     DiscoveredSkill,
+    DiscoveryLocationScope,
     InspectedPath,
     InspectedServer,
     InspectedSkill,
@@ -681,6 +682,36 @@ async def test_glob_discovers_plugin_mcp_configs():
 
 
 @pytest.mark.asyncio
+async def test_legacy_discovery_skips_selected_location_before_plugin_glob(tmp_path):
+    home = tmp_path / "user"
+    client_root = home / ".fake-client"
+    client_root.mkdir(parents=True)
+    (client_root / "mcp.json").write_text('{"mcpServers": {"user-server": {"command": "user"}}}')
+    plugin = client_root / "plugins" / "cache" / "vendor" / "plugin"
+    plugin.mkdir(parents=True)
+    (plugin / ".mcp.json").write_text('{"plugin-server": {"command": "plugin"}}')
+    pattern = "~/.fake-client/plugins/cache/**/.mcp.json"
+    candidate = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=["~/.fake-client/mcp.json"],
+        skills_dir_paths=[],
+        mcp_config_globs=[pattern],
+        mcp_config_glob_scopes={pattern: DiscoveryLocationScope.EXTENSION_PLUGIN},
+    )
+
+    ctis = await get_mcp_config_per_client(
+        candidate,
+        [(home, "user")],
+        skip_discovery_scopes={DiscoveryLocationScope.EXTENSION_PLUGIN},
+    )
+
+    entries = [server for value in ctis[0].mcp_configs.values() if isinstance(value, list) for server in value]
+    assert [server.name for server in entries] == ["user-server"]
+    assert entries[0].scope is DiscoveryLocationScope.USER
+
+
+@pytest.mark.asyncio
 async def test_glob_no_matches_still_works():
     """When mcp_config_globs match nothing, the client should still be discovered with empty configs."""
     tmp = tempfile.mkdtemp()
@@ -931,3 +962,52 @@ async def test_client_detection_is_scope_independent(scoped_candidate):
         ctis = await get_mcp_config_per_client(candidate, [(home, "user")], scope=scope)
         assert len(ctis) == 1, scope
         assert ctis[0].client_path is not None, scope
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope,mcp_config_paths,skills_dir_paths",
+    [
+        (DiscoveryScope.SERVERS, [], ["~/.fake-client/skills"]),
+        (DiscoveryScope.SKILLS, ["~/.fake-client/mcp.json"], []),
+    ],
+)
+async def test_client_detection_runs_when_requested_half_has_no_configured_sources(
+    tmp_path, scope, mcp_config_paths, skills_dir_paths
+):
+    home = tmp_path / "user"
+    (home / ".fake-client").mkdir(parents=True)
+    candidate = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=mcp_config_paths,
+        skills_dir_paths=skills_dir_paths,
+    )
+
+    ctis = await get_mcp_config_per_client(candidate, [(home, "user")], scope=scope)
+
+    assert len(ctis) == 1
+    assert ctis[0].client_path == (home / ".fake-client").as_posix()
+    assert ctis[0].mcp_configs == {}
+    assert ctis[0].skills_dirs == {}
+
+
+@pytest.mark.asyncio
+async def test_client_detection_is_skipped_when_exclusions_remove_all_requested_sources(tmp_path):
+    home = tmp_path / "user"
+    (home / ".fake-client").mkdir(parents=True)
+    candidate = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=["~/.fake-client/mcp.json"],
+        skills_dir_paths=[],
+    )
+
+    ctis = await get_mcp_config_per_client(
+        candidate,
+        [(home, "user")],
+        scope=DiscoveryScope.SERVERS,
+        skip_discovery_scopes={DiscoveryLocationScope.USER},
+    )
+
+    assert ctis == []

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -1011,3 +1011,180 @@ async def test_client_detection_is_skipped_when_exclusions_remove_all_requested_
     )
 
     assert ctis == []
+
+
+def _claude_code_candidate() -> CandidateClient:
+    """A ``claude code``-shaped candidate: one config file holding both scopes."""
+    return CandidateClient(
+        name="claude code",
+        client_exists_paths=["~/.claude"],
+        mcp_config_paths=["~/.claude.json"],
+        skills_dir_paths=[],
+        mcp_config_path_nested_scopes={"~/.claude.json": {DiscoveryLocationScope.PROJECT_WORKSPACE}},
+    )
+
+
+def _write_claude_json(home: Path) -> None:
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude.json").write_text(
+        '{"mcpServers": {"user-global": {"command": "/bin/user"}},'
+        ' "projects": {"/work/repo": {"mcpServers": {"project-only": {"command": "/bin/proj"}}}}}'
+    )
+
+
+def _servers(cti: ClientToInspect) -> dict[str, DiscoveryLocationScope]:
+    return {
+        server.name: server.scope for value in cti.mcp_configs.values() if isinstance(value, list) for server in value
+    }
+
+
+@pytest.mark.asyncio
+async def test_claude_json_labels_each_server_by_its_declaring_origin(tmp_path):
+    """One config file, two scopes: the top-level block is user-global while
+    ``projects.<path>`` blocks are project-scoped. A single per-file label makes
+    one of them wrong whichever value is chosen."""
+    home = tmp_path / "user"
+    _write_claude_json(home)
+
+    ctis = await get_mcp_config_per_client(_claude_code_candidate(), [(home, "user")])
+
+    assert _servers(ctis[0]) == {
+        "user-global": DiscoveryLocationScope.USER,
+        "project-only": DiscoveryLocationScope.PROJECT_WORKSPACE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_skipping_project_scope_drops_only_the_project_servers(tmp_path):
+    """``--skip-discovery-scopes project_workspace`` is what the installed
+    SessionStart hook passes, so this is the flag's headline behaviour."""
+    home = tmp_path / "user"
+    _write_claude_json(home)
+
+    ctis = await get_mcp_config_per_client(
+        _claude_code_candidate(),
+        [(home, "user")],
+        skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE},
+    )
+
+    assert _servers(ctis[0]) == {"user-global": DiscoveryLocationScope.USER}
+
+
+@pytest.mark.asyncio
+async def test_skipping_user_scope_drops_only_the_user_servers(tmp_path):
+    home = tmp_path / "user"
+    _write_claude_json(home)
+
+    ctis = await get_mcp_config_per_client(
+        _claude_code_candidate(),
+        [(home, "user")],
+        skip_discovery_scopes={DiscoveryLocationScope.USER},
+    )
+
+    assert _servers(ctis[0]) == {"project-only": DiscoveryLocationScope.PROJECT_WORKSPACE}
+
+
+@pytest.mark.asyncio
+async def test_same_named_project_servers_both_reach_the_report(tmp_path):
+    """The same ``github`` server configured in two repos is two separate
+    registrations; both must be inspected."""
+    home = tmp_path / "user"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude.json").write_text(
+        '{"projects": {"/work/a": {"mcpServers": {"github": {"command": "/bin/a"}}},'
+        ' "/work/b": {"mcpServers": {"github": {"command": "/bin/b"}}}}}'
+    )
+
+    ctis = await get_mcp_config_per_client(_claude_code_candidate(), [(home, "user")])
+
+    entries = [server for value in ctis[0].mcp_configs.values() if isinstance(value, list) for server in value]
+    assert sorted(server.server.command for server in entries) == ["/bin/a", "/bin/b"]
+    assert {server.scope for server in entries} == {DiscoveryLocationScope.PROJECT_WORKSPACE}
+
+
+@pytest.mark.asyncio
+async def test_cwd_relative_paths_are_not_probed_for_a_scanned_home(tmp_path, monkeypatch):
+    """Phase A only receives home directories, never project roots, so a
+    relative declaration has nothing to anchor against and ``expand_path``
+    leaves it to resolve against the *scanner's* current directory. That is not
+    a project root, and under ``--scan-all-users`` the same directory is
+    reported once per home."""
+    from agent_scan.well_known_clients import get_well_known_clients
+
+    relative = [
+        (client.name, path)
+        for client in get_well_known_clients()
+        for path in (*client.client_exists_paths, *client.mcp_config_paths, *client.skills_dir_paths)
+        if not path.startswith("~") and not Path(path).is_absolute()
+    ]
+
+    assert relative == []
+
+
+@pytest.mark.asyncio
+async def test_colliding_declarations_resolve_to_the_higher_precedence_scope(tmp_path):
+    """An explicit path and a glob can name the same file with different scopes.
+    Re-keying by resolved path collapses them, so without a precedence rule the
+    label is decided by declaration order rather than by the tier that owns the
+    file. Phase B already resolves this with ``_LOCATION_SCOPE_PRECEDENCE``."""
+    from agent_scan.models.discovery import LOCATION_SCOPE_PRECEDENCE
+
+    home = tmp_path / "user"
+    plugin_dir = home / ".fake-client" / "plugins" / "cache" / "vendor" / "v1"
+    plugin_dir.mkdir(parents=True)
+    mcp_json = plugin_dir / ".mcp.json"
+    mcp_json.write_text('{"srv": {"command": "node"}}')
+
+    pattern = "~/.fake-client/plugins/cache/**/.mcp.json"
+    candidate = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=[str(mcp_json)],
+        skills_dir_paths=[],
+        mcp_config_globs=[pattern],
+        mcp_config_glob_scopes={pattern: DiscoveryLocationScope.EXTENSION_PLUGIN},
+    )
+
+    ctis = await get_mcp_config_per_client(candidate, [(home, "user")])
+
+    entries = [s for value in ctis[0].mcp_configs.values() if isinstance(value, list) for s in value]
+    assert len(entries) == 1
+    # EXTENSION_PLUGIN outranks USER, so the plugin label wins either ordering.
+    assert (
+        LOCATION_SCOPE_PRECEDENCE[DiscoveryLocationScope.EXTENSION_PLUGIN]
+        > (LOCATION_SCOPE_PRECEDENCE[DiscoveryLocationScope.USER])
+    )
+    assert entries[0].scope is DiscoveryLocationScope.EXTENSION_PLUGIN
+
+
+@pytest.mark.asyncio
+async def test_colliding_declarations_are_order_independent(tmp_path):
+    """Same collision, but the higher-precedence scope is declared on the
+    explicit path (which is inserted first) instead of the glob."""
+    from agent_scan.models.discovery import LOCATION_SCOPE_PRECEDENCE
+
+    home = tmp_path / "user"
+    conf_dir = home / ".fake-client" / "managed"
+    conf_dir.mkdir(parents=True)
+    mcp_json = conf_dir / "mcp.json"
+    mcp_json.write_text('{"mcpServers": {"srv": {"command": "node"}}}')
+
+    pattern = "~/.fake-client/managed/**/mcp.json"
+    candidate = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=[str(mcp_json)],
+        skills_dir_paths=[],
+        mcp_config_path_scopes={str(mcp_json): DiscoveryLocationScope.SYSTEM},
+        mcp_config_globs=[pattern],
+        mcp_config_glob_scopes={pattern: DiscoveryLocationScope.PROJECT_WORKSPACE},
+    )
+
+    ctis = await get_mcp_config_per_client(candidate, [(home, "user")])
+
+    entries = [s for value in ctis[0].mcp_configs.values() if isinstance(value, list) for s in value]
+    assert (
+        LOCATION_SCOPE_PRECEDENCE[DiscoveryLocationScope.SYSTEM]
+        > (LOCATION_SCOPE_PRECEDENCE[DiscoveryLocationScope.PROJECT_WORKSPACE])
+    )
+    assert [s.scope for s in entries] == [DiscoveryLocationScope.SYSTEM]

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -993,7 +993,14 @@ async def test_client_detection_runs_when_requested_half_has_no_configured_sourc
 
 
 @pytest.mark.asyncio
-async def test_client_detection_is_skipped_when_exclusions_remove_all_requested_sources(tmp_path):
+async def test_installed_client_is_still_reported_when_exclusions_remove_its_sources(tmp_path):
+    """An installed client whose every source is excluded has no in-scope
+    components -- it is not absent. Returning nothing made ``pipelines`` log
+    "does not exist on this machine" about an agent that is installed, and left
+    ``scanned_usernames`` with no username to attribute the scan to. It also
+    contradicted the sibling test above, where a client with no *configured*
+    sources for the requested half is reported with empty dicts.
+    """
     home = tmp_path / "user"
     (home / ".fake-client").mkdir(parents=True)
     candidate = CandidateClient(
@@ -1010,7 +1017,44 @@ async def test_client_detection_is_skipped_when_exclusions_remove_all_requested_
         skip_discovery_scopes={DiscoveryLocationScope.USER},
     )
 
-    assert ctis == []
+    assert len(ctis) == 1
+    assert ctis[0].client_path == (home / ".fake-client").as_posix()
+    assert ctis[0].mcp_configs == {}
+
+
+@pytest.mark.asyncio
+async def test_excluding_every_automatic_scope_reports_nothing_at_all(tmp_path):
+    """``--skip-discovery-scopes all`` is documented as excluding every automatic
+    scope, so it must not still disclose which agents are installed and where.
+    Previously a client declaring no sources for the requested half bypassed the
+    gate entirely and shipped a presence entry, while one with sources vanished.
+    """
+    from agent_scan.models import AUTOMATIC_DISCOVERY_SCOPES
+
+    home = tmp_path / "user"
+    (home / ".fake-client").mkdir(parents=True)
+    (home / ".no-sources").mkdir(parents=True)
+    with_sources = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=["~/.fake-client/mcp.json"],
+        skills_dir_paths=[],
+    )
+    without_sources = CandidateClient(
+        name="no-sources",
+        client_exists_paths=["~/.no-sources"],
+        mcp_config_paths=[],
+        skills_dir_paths=[],
+    )
+
+    for candidate in (with_sources, without_sources):
+        ctis = await get_mcp_config_per_client(
+            candidate,
+            [(home, "user")],
+            scope=DiscoveryScope.SERVERS,
+            skip_discovery_scopes=AUTOMATIC_DISCOVERY_SCOPES,
+        )
+        assert ctis == [], f"{candidate.name} still disclosed its presence"
 
 
 def _claude_code_candidate() -> CandidateClient:
@@ -1188,3 +1232,40 @@ async def test_colliding_declarations_are_order_independent(tmp_path):
         > (LOCATION_SCOPE_PRECEDENCE[DiscoveryLocationScope.PROJECT_WORKSPACE])
     )
     assert [s.scope for s in entries] == [DiscoveryLocationScope.SYSTEM]
+
+
+@pytest.mark.asyncio
+async def test_scanned_username_is_the_scanned_home_not_the_scanning_user(tmp_path):
+    """``scanned_usernames`` falls back to ``getpass.getuser()`` when no client
+    survives discovery. A *location* filter must not change which identity the
+    scan is attributed to -- before this, ``--skip-discovery-scopes user``
+    emptied the client list and stamped the scan with whoever ran the process.
+    """
+    home = tmp_path / "alice-home"
+    (home / ".fake-client").mkdir(parents=True)
+    (home / ".fake-client" / "mcp.json").write_text('{"mcpServers": {"srv": {"command": "node"}}}')
+    candidate = CandidateClient(
+        name="fake-client",
+        client_exists_paths=["~/.fake-client"],
+        mcp_config_paths=["~/.fake-client/mcp.json"],
+        skills_dir_paths=[],
+    )
+
+    from agent_scan.pipelines import discover_clients_to_inspect
+
+    args = InspectArgs(
+        timeout=1,
+        tokens=[],
+        paths=[],
+        discovery_scope=DiscoveryScope.SERVERS,
+        skip_discovery_scopes={DiscoveryLocationScope.USER},
+    )
+    with (
+        patch("agent_scan.pipelines.get_readable_home_directories", return_value=[(home, "alice")]),
+        patch("agent_scan.pipelines.get_well_known_clients", return_value=[candidate]),
+        patch("agent_scan.pipelines.find_discoverers", return_value=[]),
+    ):
+        _, _, scanned_usernames = await discover_clients_to_inspect(args)
+
+    assert scanned_usernames == ["alice"]
+    assert getpass.getuser() not in scanned_usernames or getpass.getuser() == "alice"

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -1,5 +1,7 @@
 import getpass
+import json
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -1269,3 +1271,58 @@ async def test_scanned_username_is_the_scanned_home_not_the_scanning_user(tmp_pa
 
     assert scanned_usernames == ["alice"]
     assert getpass.getuser() not in scanned_usernames or getpass.getuser() == "alice"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signing_returncode, expected_identifier", [(0, "com.example.mcp"), (1, None)])
+async def test_explicit_config_preserves_binary_identifier_through_inspection(
+    tmp_path, monkeypatch, signing_returncode, expected_identifier
+):
+    from agent_scan.pipelines import client_to_inspect_from_path
+
+    binary = tmp_path / "signed-server"
+    binary.write_text("")
+    binary.chmod(0o755)
+    config = tmp_path / "mcp.json"
+    config.write_text(json.dumps({"mcpServers": {"signed": {"command": str(binary)}}}))
+    monkeypatch.setattr("agent_scan.signed_binary.sys.platform", "darwin")
+
+    def codesign(args, **kwargs):
+        assert args == ["codesign", "-dvvv", str(binary)]
+        return subprocess.CompletedProcess(
+            args, signing_returncode, stdout="", stderr="Identifier=com.example.mcp\nAuthority=Apple Root CA\n"
+        )
+
+    monkeypatch.setattr(subprocess, "run", codesign)
+    clients = await client_to_inspect_from_path(str(config), True, [(tmp_path, "alice")], False)
+    entry = next(iter(clients[0].mcp_configs.values()))[0]
+    assert entry.server.binary_identifier == expected_identifier
+    inspected = await inspect_client(clients[0], timeout=0, tokens=[], scan_skills=False, do_stdio_handshake=False)
+    assert inspected.servers[0].server.binary_identifier == expected_identifier
+    assert inspected.model_dump()["servers"][0]["server"]["binary_identifier"] == expected_identifier
+
+
+@pytest.mark.asyncio
+async def test_legacy_discovery_does_not_check_signatures_for_remote_or_excluded_servers(tmp_path, monkeypatch):
+    config = tmp_path / "mcp.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {"remote": {"url": "https://example.com/mcp"}},
+                "projects": {str(tmp_path / "repo"): {"mcpServers": {"excluded": {"command": "excluded-server"}}}},
+            }
+        )
+    )
+    client = CandidateClient(
+        name="legacy", client_exists_paths=[str(config)], mcp_config_paths=[str(config)], skills_dir_paths=[]
+    )
+    monkeypatch.setattr("agent_scan.signed_binary.sys.platform", "darwin")
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: pytest.fail("unexpected signature check"))
+
+    clients = await get_mcp_config_per_client(
+        client, [(tmp_path, "alice")], skip_discovery_scopes={DiscoveryLocationScope.PROJECT_WORKSPACE}
+    )
+    entries = next(iter(clients[0].mcp_configs.values()))
+    assert [entry.name for entry in entries] == ["remote"]
+    assert isinstance(entries[0].server, RemoteServer)
+    assert entries[0].server.url == "https://example.com/mcp"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -12,7 +12,26 @@ class TestInspectionResults:
 
         assert skill.name == "git:commit"
         assert skill.path == "/project/.claude/commands/git/commit.md"
-        assert set(skill.model_dump()) == {"name", "path"}
+        assert skill.model_dump() == {
+            "name": "git:commit",
+            "path": "/project/.claude/commands/git/commit.md",
+            "scope": "custom",
+        }
+
+    def test_legacy_discovered_server_pair_is_normalized_as_custom(self):
+        from agent_scan.models import ClientToInspect, DiscoveredServer, DiscoveryLocationScope, StdioServer
+
+        client = ClientToInspect(
+            name="custom",
+            client_path="/custom",
+            mcp_configs={"/custom/config.json": [("server", StdioServer(command="server"))]},
+            skills_dirs={},
+        )
+
+        discovered = client.mcp_configs["/custom/config.json"]
+        assert isinstance(discovered, list)
+        assert isinstance(discovered[0], DiscoveredServer)
+        assert discovered[0].scope is DiscoveryLocationScope.CUSTOM
 
     def test_v20260710_wire_models_are_distinct_from_inspection_models(self):
         from agent_scan.models.api.v20260710 import McpServerRequest, ScanPathRequest, SkillRequest

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -441,3 +441,30 @@ class TestMCPServerMap:
 
         with pytest.raises(ValidationError):
             MCPServerMap(servers={"bad": {"not_a": "server"}})
+
+
+def test_legacy_discovered_server_pair_survives_a_json_round_trip():
+    """A tuple becomes a list once serialized, so a tuple-only check would
+    reject the same value coming back in."""
+    from agent_scan.models import DiscoveredServer, DiscoveryLocationScope, StdioServer
+
+    from_list = DiscoveredServer.model_validate(["srv", StdioServer(command="node")])
+
+    assert from_list.name == "srv"
+    assert from_list.server.command == "node"
+    assert from_list.scope is DiscoveryLocationScope.CUSTOM
+
+
+def test_guard_wire_model_stays_in_field_parity_with_the_analysis_one():
+    """``GuardScanPathRequest`` is deliberately not a ``ScanPathRequest``
+    subclass, so nothing structurally stops the two drifting apart."""
+    from agent_scan.models.api.v20260710 import GuardScanPathRequest, ScanPathRequest
+
+    assert set(GuardScanPathRequest.model_fields) == set(ScanPathRequest.model_fields)
+
+
+def test_guard_server_wire_model_adds_only_scope():
+    from agent_scan.models.api.v20260710 import GuardMcpServerRequest, McpServerRequest
+
+    extra = set(GuardMcpServerRequest.model_fields) - set(McpServerRequest.model_fields)
+    assert extra == {"scope"}


### PR DESCRIPTION
## Summary

Adds per-location-scope discovery filtering: a `DiscoveryLocationScope` tier on every discovered MCP
server and skill, a `guard discover --skip-discovery-scopes` CSV flag, and a generated SessionStart
hook that passes `project_workspace` so session-start telemetry reports system/user/extension
components only.

Scope is derived from **where a component lives**, not from which file declared it. A single config
file can mix tiers (`~/.claude.json` holds user-global servers alongside per-project ones), so the
exclusion is applied per entry rather than per file.

- Location scope on `DiscoveredServer` / `DiscoveredSkill`, plumbed through both discovery phases.
- `guard discover --skip-discovery-scopes {system,user,project_workspace,extension_plugin,all}`.
- Guard's `sessionStartServerDiscovery` event carries `scope`; the analysis wire deliberately does
  not, and neither does `inspect --json`.
- Per-agent source filtering across the legacy candidate list and the ABC discoverers, including
  plugin globs and OpenCode config-declared skill paths.

## Review round

`/code-review` on the first two commits raised 17 findings. All are addressed, in seven commits:

| Commit | What it fixes |
| --- | --- |
| `derive location scope from where a component lives` | Per-entry scope for `~/.claude.json`; containment guard so a `project_workspace` claim must resolve inside a real project root; platform-independent `skills.paths` classification; `$OPENCODE_CONFIG` scoped by location |
| `keep detected clients in scoped reports` | Detection always runs; `all` withholds presence too; scan username no longer falls back to the scanning user |
| `carry discovery scope through the versioned wire models` | Replaces post-serialization dict mutation with Guard-specific request models |
| `make the discovery-scope hook flag survive a multi-value CSV` | PowerShell array-coercion; quoting parity; `ValidatePattern` on the one unguarded `.ps1` parameter |
| `harden discoverer construction and the platform client merge` | Constructor inside the failure guard; complete WSL dedupe key; validator for scope-override keys |
| `clear all mypy errors and make the pre-commit gate real` | 40 → 0 errors, and a gate that actually runs against project types |
| `docs, dead code, and redundant scaffolding` | Dead helpers, stale docstring, redundant branches, SQLite re-reads |

### Two findings were downgraded after investigation

**"Merge order is an unasserted invariant" — not a live defect.** The claim was that Cursor merging
`USER`/`EXTENSION_PLUGIN` after `super()` has merged `SYSTEM` makes those merges silent no-ops, so
`~/.cursor/skills-cursor` "disappears with no error". Reproduced with a forced collision between
Cursor's SYSTEM dir and its builtin USER dir: the path **survives**, labelled `system`. The losing
merge is a no-op precisely because `SYSTEM` outranks `USER` — the precedence table working as
designed. Label resolution is already order-independent for distinct precedences. Pinned with a
regression test rather than restructuring nine discoverers.

**"Unquoted `-SkipDiscoveryScopes` kills the SessionStart event" — latent, not shipping-broken.**
`guard install` hardcodes the single token `project_workspace`, which has no comma, so PowerShell
binds it as a plain string today. The array-coercion bug fires only once a second scope joins the
CSV. Fixed anyway, since the flag is documented and parsed as CSV. Relatedly, `_render_argv` was
flagged as a quoting bug but is not one — argv elements go to `subprocess` directly.

### Pre-existing bugs found and fixed along the way

- `ClaudeCodeConfigFile` declared only `projects`, so a real `~/.claude.json` carrying both keys lost
  its user-global servers entirely, and same-named servers across projects collapsed to whichever
  project came last.
- `Completion` was in the `Entity` type alias although `ServerSignature` has no completions field,
  making every `entity.name` access unsound.
- `_apply_ignore_risks` inferred `list[McpServerRiskIndexes]` and then extended it with
  `SkillRiskIndexes`.
- Phase A called `check_server_signature` and discarded the result, so it never attached signature
  data — a `codesign` subprocess per stdio server inside the hook's 5s budget, for nothing.

### Deliberate behaviour reduction

The CWD-relative Phase A declarations (`.openclaw/skills`, `.amp/skills`, amp's `.amp` probe) are
removed. Phase A only receives home directories, so these resolved against the *scanner's* working
directory — not any project root — and were re-probed once per home under `--scan-all-users`. This
also restores the two README footnotes the branch had falsified.

## The pre-commit mypy gate was blind

`.pre-commit-config.yaml` used `mirrors-mypy` with only `types-requests` and `types-PyYAML`, so with
`ignore_missing_imports = true` pydantic's `BaseModel` degraded to `Any` and every pydantic-derived
error vanished. Reproduced: the hook's isolated environment reported `Success: no issues found in 45
source files` on a tree where a project-environment run reported 40. CI has no direct mypy step, so
the gap was invisible there too.

Replaced with a local hook running `uv run --with mypy mypy` over the package, and verified it now
fails on a deliberately introduced error. **CI will enforce types here for the first time.**

Note `ruff` has the same version drift — pre-commit pins v0.11.8 while the `dev` extra resolves to
0.15.0, so a local run reports 68 findings the hook does not. Left alone as out of scope; this branch
adds none of them (68 before, 68 after).

## Validation

- Full suite diffed as failure *sets* against a clean worktree at the pre-review commit:
  **zero new failures**. The raw counts differ (86 → 35) only because the `[binary]` e2e parameters
  need a built `dist/`, which the fresh worktree lacks; all 51 of the difference are
  `binary`-parametrized.
- `uv run --with mypy mypy --config-file=pyproject.toml src/agent_scan/` → **0 errors** (was 40).
- `pre-commit run --all-files` clean.
- End-to-end through the real discovery path, with a `~/.claude.json` holding both a top-level and a
  project server: `--skip-discovery-scopes project_workspace` drops the project server and keeps the
  user-global one; `--skip-discovery-scopes user` does the inverse. Both were wrong before.

Remaining local failures are environment-dependent and pre-existing: 8 in `test_verify_api.py`
(`SNYK_TOKEN` unset) plus the `[binary]` e2e parameters.
