### PR TITLE
[ADS-1115] Install Codex SubagentStart hook

### DIFF
--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -105,6 +105,7 @@ CODEX_HOOK_EVENTS = [
     "UserPromptSubmit",
     "Stop",
     "SessionStart",
+    "SubagentStart",
 ]
 
 CURSOR_HOOK_EVENTS = [

--- a/tests/e2e/test_guard_install.py
+++ b/tests/e2e/test_guard_install.py
@@ -212,6 +212,7 @@ class TestGuardInstallE2E:
         data = json.loads(config_file.read_text())
         assert "PreToolUse" in data["hooks"]
         assert "Stop" in data["hooks"]
+        assert "SubagentStart" in data["hooks"]
 
         discover_script = "snyk-agent-guard-discover.ps1" if os.name == "nt" else "snyk-agent-guard-discover.sh"
         discovery_groups = [


### PR DESCRIPTION
**Summary**

Register `SubagentStart` in generated Codex hook configurations so Agent Guidance can deliver session-start steering to newly spawned Codex subagents.

**Verification**

The source-path Codex guard-install E2E test passes, and the generated configuration test now asserts that `SubagentStart` is installed. Repository pre-commit checks also pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive hook registration only; no changes to auth, forwarding logic, or existing hook behavior beyond one new Codex event.
> 
> **Overview**
> Codex **Agent Guard** installs now register the **`SubagentStart`** hook alongside existing Codex events, so steering/guidance can run when Codex spawns a subagent (same pattern as Claude’s subagent hooks).
> 
> The change is limited to extending **`CODEX_HOOK_EVENTS`** in `guard.py`, which drives generated user `hooks.json` and managed `requirements.toml` during install. The Codex guard-install E2E test asserts **`SubagentStart`** appears in the written config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8835654d34deee3a4d066710b74ccf18041cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->