### PR TITLE
fix: report skills during Guard discovery

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -356,7 +356,8 @@ snyk-agent-scan guard install {claude,cursor,codex,all} [OPTIONS]
 ```
 
 After configuring the hooks, installation sends a `hooksConfiguredServerDiscovery` event. It also configures a
-fire-and-forget session-start hook that reports discovered MCP servers with a `sessionStartServerDiscovery` event.
+fire-and-forget session-start hook that reports discovered MCP servers and skill metadata with a
+`sessionStartServerDiscovery` event. Skill file contents remain exclusive to explicit and periodic scans.
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -374,14 +375,14 @@ snyk-agent-scan guard discover [OPTIONS]
 ```
 
 This internal command is invoked by the SessionStart hook configured by `guard install`. It reads the current target
-folder(s) from the selected client's hook payload, discovers MCP servers locally, and sends the resulting
+folder(s) from the selected client's hook payload, discovers MCP servers and skills locally, and sends the resulting
 `sessionStartServerDiscovery` event directly to Agent Monitor; it is not normally run by hand.
 
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--url URL` | string | `https://api.snyk.io` | Remote hook base URL for the Snyk API environment. |
 | `--client {claude-code,cursor,codex}` | string | required | Hook client whose target-folder payload and endpoint conventions should be used. |
-| `--scope {servers,skills,all}` | string | `all` | Discovery data to collect. The session-start hook installed by `guard install` passes `servers`, because the event it sends carries MCP servers only. |
+| `--scope {servers,skills,all}` | string | `all` | Discovery data to collect. The session-start hook installed by `guard install` passes `all`. The event carries the selected value as `discovery_scope` so receivers only reconcile the component types covered by that event. |
 
 ### `guard uninstall`
 

--- a/src/agent_scan/cli.py
+++ b/src/agent_scan/cli.py
@@ -974,7 +974,7 @@ def main():
         "discover",
         allow_abbrev=False,
         help=(
-            "Run MCP server discovery and send a sessionStartServerDiscovery event directly to Agent Monitor "
+            "Run component discovery and send a sessionStartServerDiscovery event directly to Agent Monitor "
             "(used by the async session-start hooks that guard install configures)"
         ),
     )

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -326,7 +326,7 @@ def _run_install(args) -> None:
             url,
             first_installed_client,
             machine_id,
-            discovery_scope=DiscoveryScope.SERVERS,
+            discovery_scope=DiscoveryScope.ALL,
             max_retries=2,
         )
 
@@ -1141,19 +1141,25 @@ def _detect_install(path: Path, events: list[str], commands: Callable[[dict], It
 
 
 def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> list[dict]:
-    """Serialize discovered clients exactly as ``scan`` serializes them for analysis."""
+    """Serialize discovered component metadata in the regular scan wire shape.
+
+    Guard discovery intentionally omits skill file contents. Session-start hooks
+    need enough metadata to keep the machine inventory current, without repeatedly
+    reading and uploading every file in every installed skill.
+    """
     from agent_scan.inspect import (
         _config_error_to_scan_error,
         _inspection_component_name,
         _join_scan_errors,
     )
-    from agent_scan.models import InspectedPath, InspectedServer, ScanError
+    from agent_scan.models import InspectedPath, InspectedServer, InspectedSkill, ScanError
     from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, UnknownConfigFormat
     from agent_scan.verify_api import build_scan_request
 
     inspected_paths: list[InspectedPath] = []
     for client in clients_to_inspect:
         servers: list[InspectedServer] = []
+        skills: list[InspectedSkill] = []
         config_errors: list[ScanError] = []
         for config_path, discovered in client.mcp_configs.items():
             if isinstance(discovered, FileNotFoundConfig | UnknownConfigFormat | CouldNotParseMCPConfig):
@@ -1167,11 +1173,23 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
                 )
                 for name, server in discovered
             )
+        for discovered in client.skills_dirs.values():
+            if isinstance(discovered, FileNotFoundConfig):
+                config_errors.append(_config_error_to_scan_error(discovered))
+                continue
+            skills.extend(
+                InspectedSkill(
+                    name=_inspection_component_name(skill.name, "skill", skill.path),
+                    installation_path=skill.path,
+                )
+                for skill in discovered
+            )
         inspected_paths.append(
             InspectedPath(
                 client=client.name,
                 path=client.client_path,
                 servers=servers,
+                skills=skills,
                 error=_join_scan_errors(config_errors),
             )
         )
@@ -1314,23 +1332,24 @@ def _send_servers_discovered_event(
     discovery_scope: DiscoveryScope = DiscoveryScope.ALL,
     max_retries: int = 1,
 ) -> bool:
-    """Discover MCP servers and send an install- or session-scoped discovery event.
+    """Discover component metadata and send an install- or session-scoped discovery event.
 
     The default event follows ``hooksConfigured`` during installation. Session-start
     callers override it with ``sessionStartServerDiscovery``.
     """
-    rich.print("[dim]Discovering MCP servers...[/dim]")
+    rich.print("[dim]Discovering agent components...[/dim]")
     started = time.monotonic()
     try:
         servers = _discover_servers_payload(target_folders, discovery_scope=discovery_scope)
     except Exception as e:
-        rich.print(f"[yellow]Warning:[/yellow] Could not discover MCP servers: {e}")
+        rich.print(f"[yellow]Warning:[/yellow] Could not discover agent components: {e}")
         return False
     duration_ms = round((time.monotonic() - started) * 1000)
 
     payload_dict: dict = {
         "hook_event_name": event_name,
         "servers": servers,
+        "discovery_scope": DiscoveryScope(discovery_scope).value,
         "discovery_duration_ms": duration_ms,
     }
     payload_dict[HOOK_CLIENTS[hook_client].session_field] = session_marker
@@ -1340,10 +1359,15 @@ def _send_servers_discovered_event(
     ok, detail = send_hook_event(url, hook_client, push_key, payload, machine_id, max_retries=max_retries)
     if ok:
         server_count = sum(len(entry.get("servers", [])) for entry in servers)
-        noun = "server" if server_count == 1 else "servers"
-        rich.print(f"[green]\u2713[/green]  Discovered {server_count} MCP {noun}  [green]\u2192 OK[/green]")
+        skill_count = sum(len(entry.get("skills", [])) for entry in servers)
+        server_noun = "server" if server_count == 1 else "servers"
+        skill_noun = "skill" if skill_count == 1 else "skills"
+        rich.print(
+            f"[green]\u2713[/green]  Discovered {server_count} MCP {server_noun} "
+            f"and {skill_count} {skill_noun}  [green]\u2192 OK[/green]"
+        )
         return True
-    rich.print(f"[yellow]Warning:[/yellow] Could not send discovered MCP servers: {detail}")
+    rich.print(f"[yellow]Warning:[/yellow] Could not send discovered agent components: {detail}")
     return False
 
 
@@ -1704,7 +1728,7 @@ def _build_discover_hook_command(
         url=url,
         machine_id=machine_id,
         agent_scan_command=agent_scan_command,
-        scope="servers",
+        scope="all",
         quote_client=True,
     )
     if IS_WINDOWS:

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1154,6 +1154,7 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
     )
     from agent_scan.models import InspectedPath, InspectedServer, InspectedSkill, ScanError
     from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig, UnknownConfigFormat
+    from agent_scan.skill_client import resolve_skill_name
     from agent_scan.verify_api import build_scan_request
 
     inspected_paths: list[InspectedPath] = []
@@ -1177,13 +1178,25 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
             if isinstance(discovered, FileNotFoundConfig):
                 config_errors.append(_config_error_to_scan_error(discovered))
                 continue
-            skills.extend(
-                InspectedSkill(
-                    name=_inspection_component_name(skill.name, "skill", skill.path),
-                    installation_path=skill.path,
+            for skill in discovered:
+                skill_name = skill.name
+                skill_error = None
+                try:
+                    skill_name = resolve_skill_name(skill)
+                except Exception as error:
+                    skill_error = ScanError(
+                        message="could not inspect skill",
+                        exception=str(error),
+                        is_failure=True,
+                        category="skill_scan_error",
+                    )
+                skills.append(
+                    InspectedSkill(
+                        name=_inspection_component_name(skill_name, "skill", skill.path),
+                        installation_path=skill.path,
+                        error=skill_error,
+                    )
                 )
-                for skill in discovered
-            )
         inspected_paths.append(
             InspectedPath(
                 client=client.name,

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1174,11 +1174,11 @@ def _servers_discovered_entries(clients_to_inspect: list[ClientToInspect]) -> li
                 )
                 for name, server in discovered
             )
-        for discovered in client.skills_dirs.values():
-            if isinstance(discovered, FileNotFoundConfig):
-                config_errors.append(_config_error_to_scan_error(discovered))
+        for skill_entries in client.skills_dirs.values():
+            if isinstance(skill_entries, FileNotFoundConfig):
+                config_errors.append(_config_error_to_scan_error(skill_entries))
                 continue
-            for skill in discovered:
+            for skill in skill_entries:
                 skill_name = skill.name
                 skill_error = None
                 try:

--- a/src/agent_scan/hooks/snyk-agent-guard-discover.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard-discover.ps1
@@ -22,7 +22,7 @@ param(
 
     [Parameter(Mandatory=$false)]
     [ValidateSet("servers","skills","all")]
-    [string]$Scope = "servers"
+    [string]$Scope = "all"
 )
 
 $ErrorActionPreference = "Stop"

--- a/tests/e2e/test_guard_install.py
+++ b/tests/e2e/test_guard_install.py
@@ -127,11 +127,9 @@ class TestGuardInstallE2E:
         assert session_discovery["body"]["discovery_duration_ms"] >= 0
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
-    def test_guard_discover_reports_server_and_skill_metadata(
-        self, agent_scan_cmd, tmp_path, fake_hook_server
-    ):
+    def test_guard_discover_reports_server_and_skill_metadata(self, agent_scan_cmd, tmp_path, fake_hook_server):
         home = tmp_path / "home"
-        skills_dir = home / ".claude" / "skills" / "docker-sandbox-skill"
+        skills_dir = home / ".claude" / "skills" / "docker-sandbox-skill-directory"
         skills_dir.mkdir(parents=True)
         (home / ".claude.json").write_text(
             json.dumps(
@@ -169,9 +167,7 @@ class TestGuardInstallE2E:
             },
         )
 
-        assert result.returncode == 0, (
-            f"guard discover failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"guard discover failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
         payload = _FakeHookServer.requests[-1]["body"]
         assert payload["hook_event_name"] == "sessionStartServerDiscovery"
         assert payload["discovery_scope"] == "all"

--- a/tests/e2e/test_guard_install.py
+++ b/tests/e2e/test_guard_install.py
@@ -127,6 +127,67 @@ class TestGuardInstallE2E:
         assert session_discovery["body"]["discovery_duration_ms"] >= 0
 
     @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
+    def test_guard_discover_reports_server_and_skill_metadata(
+        self, agent_scan_cmd, tmp_path, fake_hook_server
+    ):
+        home = tmp_path / "home"
+        skills_dir = home / ".claude" / "skills" / "docker-sandbox-skill"
+        skills_dir.mkdir(parents=True)
+        (home / ".claude.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "docker-sandbox-mcp": {
+                            "command": "/bin/false",
+                            "args": [],
+                        }
+                    }
+                }
+            )
+        )
+        skill_path = skills_dir / "SKILL.md"
+        skill_path.write_text(
+            "---\n"
+            "name: docker-sandbox-skill\n"
+            "description: Reproduction skill inside Docker Sandbox.\n"
+            "---\n"
+            "Test instructions.\n"
+        )
+
+        result = subprocess.run(
+            [*agent_scan_cmd, "guard", "discover", "--client", "claude-code", "--scope", "all"],
+            input=json.dumps({"cwd": str(tmp_path), "session_id": "docker-sandbox-session"}),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={
+                **os.environ,
+                "HOME": str(home),
+                "PUSH_KEY": "test-pk-e2e",
+                "REMOTE_HOOKS_BASE_URL": fake_hook_server,
+                "MACHINE_ID": "docker-sandbox-machine",
+            },
+        )
+
+        assert result.returncode == 0, (
+            f"guard discover failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        payload = _FakeHookServer.requests[-1]["body"]
+        assert payload["hook_event_name"] == "sessionStartServerDiscovery"
+        assert payload["discovery_scope"] == "all"
+        assert payload["session_id"] == "docker-sandbox-session"
+        claude_entry = next(entry for entry in payload["servers"] if entry["client"] == "claude code")
+        assert [server["name"] for server in claude_entry["servers"]] == ["docker-sandbox-mcp"]
+        assert claude_entry["skills"] == [
+            {
+                "name": "docker-sandbox-skill",
+                "installation_path": str(skills_dir),
+                "files": [],
+                "error": None,
+            }
+        ]
+
+    @pytest.mark.parametrize("agent_scan_cmd", ["uv", "binary"], indirect=True)
     def test_guard_install_cursor(self, agent_scan_cmd, agent_scan_command, tmp_path, fake_hook_server):
         config_file = tmp_path / "hooks.json"
         result = subprocess.run(

--- a/tests/e2e/test_guard_install.py
+++ b/tests/e2e/test_guard_install.py
@@ -161,6 +161,7 @@ class TestGuardInstallE2E:
             env={
                 **os.environ,
                 "HOME": str(home),
+                "USERPROFILE": str(home),
                 "PUSH_KEY": "test-pk-e2e",
                 "REMOTE_HOOKS_BASE_URL": fake_hook_server,
                 "MACHINE_ID": "docker-sandbox-machine",

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -62,7 +62,7 @@ from agent_scan.guard import (
     _write_codex_managed_config,
     _write_config,
 )
-from agent_scan.models import ClientToInspect, InspectedPath, InspectedServer, RemoteServer, StdioServer
+from agent_scan.models import ClientToInspect, DiscoveredSkill, InspectedPath, InspectedServer, RemoteServer, StdioServer
 from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig
 from agent_scan.pushkeys import GuardEnabledAccessDeniedError
 
@@ -251,14 +251,14 @@ class TestExtractEnvFromCmd:
             False,
             "PUSH_KEY='pk' REMOTE_HOOKS_BASE_URL='https://api.snyk.io' MACHINE_ID='machine' "
             "AGENT_SCAN_COMMAND='/usr/local/bin/snyk-agent-scan' bash '/x/snyk-agent-guard-discover.sh' "
-            "--client 'claude-code' --scope servers",
+            "--client 'claude-code' --scope all",
         ),
         (
             "discover",
             True,
             "powershell -File 'C:\\hooks\\snyk-agent-guard-discover.ps1' -Client claude-code -PushKey 'pk' "
             "-RemoteUrl 'https://api.snyk.io' -MachineId 'machine' "
-            "-AgentScanCommand 'C:\\Program Files\\Snyk\\snyk-agent-scan.exe' -Scope servers",
+            "-AgentScanCommand 'C:\\Program Files\\Snyk\\snyk-agent-scan.exe' -Scope all",
         ),
     ],
 )
@@ -469,7 +469,7 @@ class TestBuildDiscoverHookCommand:
         assert "TENANT_ID=" not in command
         assert "MACHINE_ID='machine'" in command
         assert "AGENT_SCAN_COMMAND='/opt/Snyk'\"'\"'s bin/snyk-agent-scan'" in command
-        assert command.endswith(f"bash '/x/snyk-agent-guard-discover.sh' --client '{client}' --scope servers")
+        assert command.endswith(f"bash '/x/snyk-agent-guard-discover.sh' --client '{client}' --scope all")
         assert _is_agent_scan_command(command)
 
     @pytest.mark.parametrize("client", ["claude-code", "cursor", "codex"])
@@ -488,7 +488,7 @@ class TestBuildDiscoverHookCommand:
         assert command == (
             rf"powershell -File 'C:\hooks\snyk-agent-guard-discover.ps1' -Client {client} "
             "-PushKey 'pk' -RemoteUrl 'https://api.snyk.io' -MachineId 'machine''s-id' "
-            r"-AgentScanCommand 'C:\Program Files\Snyk\snyk-agent-scan.exe' -Scope servers"
+            r"-AgentScanCommand 'C:\Program Files\Snyk\snyk-agent-scan.exe' -Scope all"
         )
 
     def test_powershell_escapes_single_quotes_in_paths(self):
@@ -3121,7 +3121,7 @@ class TestPowerShellDiscoveryHookScript:
 
         assert result.returncode == 0, result.stderr
         recorded = marker.read_text().splitlines()
-        assert recorded[0] == "guard discover --client claude-code --scope servers"
+        assert recorded[0] == "guard discover --client claude-code --scope all"
         assert json.loads("\n".join(recorded[1:])) == json.loads(payload)
 
     def test_nonzero_discovery_exit_is_swallowed(self, tmp_path):
@@ -4295,12 +4295,12 @@ class TestSendTestEventHooksScript:
 
 class TestServersDiscoveredPayload:
     @staticmethod
-    def _client(*, mcp_configs, name="claude code", path=None):
+    def _client(*, mcp_configs, skills_dirs=None, name="claude code", path=None):
         return ClientToInspect(
             name=name,
             client_path=path or (Path.home() / ".claude").as_posix(),
             mcp_configs=mcp_configs,
-            skills_dirs={},
+            skills_dirs=skills_dirs or {},
         )
 
     def test_builds_one_entry_per_client_and_merges_config_paths(self):
@@ -4337,6 +4337,40 @@ class TestServersDiscoveredPayload:
             ("remote", (home / "project" / ".mcp.json").as_posix()),
         ]
         assert result[1]["servers"] == []
+
+    def test_serializes_skill_metadata_without_reading_skill_files(self):
+        skill_path = (Path.home() / ".claude" / "skills" / "sandbox-skill").as_posix()
+        client = self._client(
+            mcp_configs={},
+            skills_dirs={
+                (Path.home() / ".claude" / "skills").as_posix(): [
+                    DiscoveredSkill(name="sandbox-skill", path=skill_path)
+                ]
+            },
+        )
+
+        result = guard_module._servers_discovered_entries([client])
+
+        assert result[0]["servers"] == []
+        assert result[0]["skills"] == [
+            {
+                "name": "sandbox-skill",
+                "installation_path": skill_path,
+                "files": [],
+                "error": None,
+            }
+        ]
+
+    def test_reports_skill_discovery_errors(self):
+        client = self._client(
+            mcp_configs={},
+            skills_dirs={"/missing-skills": FileNotFoundConfig(message="missing skills", traceback=None)},
+        )
+
+        result = guard_module._servers_discovered_entries([client])
+
+        assert result[0]["skills"] == []
+        assert result[0]["error"]["category"] == "file_not_found"
 
     def test_reports_config_discovery_errors(self):
         client = self._client(
@@ -4618,11 +4652,35 @@ class TestSendServersDiscoveredEvent:
         assert captured["client"] == hook_client
         assert captured["push_key"] == "pk-test"
         assert captured["machine_id"] == "machine-42"
+        assert payload["discovery_scope"] == "all"
 
     def test_empty_discovery_is_still_sent(self):
         ok, captured = self._capture(entries=[])
         assert ok is True
         assert captured["payload"]["servers"] == []
+
+    def test_payload_reports_requested_discovery_scope(self):
+        captured = {}
+
+        def fake_send(_url, _client, _push_key, payload, _machine_id, **kwargs):
+            captured["payload"] = json.loads(payload)
+            return True, ""
+
+        with (
+            patch(f"{_G}._discover_servers_payload", return_value=[]),
+            patch(f"{_G}.send_hook_event", side_effect=fake_send),
+            patch(f"{_G}.rich"),
+        ):
+            ok = guard_module._send_servers_discovered_event(
+                "pk",
+                "https://api.snyk.io",
+                "claude-code",
+                "machine-42",
+                discovery_scope=guard_module.DiscoveryScope.SKILLS,
+            )
+
+        assert ok is True
+        assert captured["payload"]["discovery_scope"] == "skills"
 
     def test_event_name_and_session_marker_can_be_overridden(self):
         captured = {}
@@ -4882,6 +4940,7 @@ class TestRunDiscover:
         assert captured["payload"] == {
             "hook_event_name": "sessionStartServerDiscovery",
             "servers": [],
+            "discovery_scope": "all",
             "session_id": "session-start-server-discovery",
         }
         assert captured["url"] == "https://env-hooks.example"
@@ -5202,12 +5261,11 @@ class TestRunInstallSendsServersDiscovered:
             "https://api.snyk.io",
             "claude-code",
             "machine-42",
-            discovery_scope=DiscoveryScope.SERVERS,
+            discovery_scope=DiscoveryScope.ALL,
             max_retries=2,
         )
 
-    def test_install_does_not_request_skills_discovery(self, tmp_path, monkeypatch):
-        """The install event only ever reports servers, so it must not pay for a skills sweep."""
+    def test_install_requests_full_component_discovery(self, tmp_path, monkeypatch):
         from agent_scan.agents import DiscoveryScope
 
         monkeypatch.setenv("PUSH_KEY", "headless-pk")
@@ -5217,7 +5275,7 @@ class TestRunInstallSendsServersDiscovered:
         ):
             _run_install(self._args(tmp_path, machine_id="machine-42"))
 
-        assert send.call_args.kwargs["discovery_scope"] is DiscoveryScope.SERVERS
+        assert send.call_args.kwargs["discovery_scope"] is DiscoveryScope.ALL
 
     def test_install_retries_delivery_unlike_session_start(self, tmp_path, monkeypatch):
         """``guard install`` is a one-shot the user is watching, so a transport blip retries."""

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -62,7 +62,14 @@ from agent_scan.guard import (
     _write_codex_managed_config,
     _write_config,
 )
-from agent_scan.models import ClientToInspect, DiscoveredSkill, InspectedPath, InspectedServer, RemoteServer, StdioServer
+from agent_scan.models import (
+    ClientToInspect,
+    DiscoveredSkill,
+    InspectedPath,
+    InspectedServer,
+    RemoteServer,
+    StdioServer,
+)
 from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig
 from agent_scan.pushkeys import GuardEnabledAccessDeniedError
 
@@ -4338,15 +4345,20 @@ class TestServersDiscoveredPayload:
         ]
         assert result[1]["servers"] == []
 
-    def test_serializes_skill_metadata_without_reading_skill_files(self):
-        skill_path = (Path.home() / ".claude" / "skills" / "sandbox-skill").as_posix()
+    def test_serializes_canonical_skill_metadata_without_collecting_skill_files(self, tmp_path):
+        skill_dir = tmp_path / "sandbox-skill-directory"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: canonical-sandbox-skill\n"
+            "description: Reproduction skill inside Docker Sandbox.\n"
+            "---\n"
+            "Test instructions.\n"
+        )
+        skill_path = skill_dir.as_posix()
         client = self._client(
             mcp_configs={},
-            skills_dirs={
-                (Path.home() / ".claude" / "skills").as_posix(): [
-                    DiscoveredSkill(name="sandbox-skill", path=skill_path)
-                ]
-            },
+            skills_dirs={tmp_path.as_posix(): [DiscoveredSkill(name="sandbox-skill", path=skill_path)]},
         )
 
         result = guard_module._servers_discovered_entries([client])
@@ -4354,12 +4366,26 @@ class TestServersDiscoveredPayload:
         assert result[0]["servers"] == []
         assert result[0]["skills"] == [
             {
-                "name": "sandbox-skill",
+                "name": "canonical-sandbox-skill",
                 "installation_path": skill_path,
                 "files": [],
                 "error": None,
             }
         ]
+
+    def test_skill_metadata_error_does_not_abort_discovery(self, tmp_path):
+        skill_dir = tmp_path / "invalid-skill"
+        skill_dir.mkdir()
+        client = self._client(
+            mcp_configs={},
+            skills_dirs={tmp_path.as_posix(): [DiscoveredSkill(name="invalid-skill", path=skill_dir.as_posix())]},
+        )
+
+        result = guard_module._servers_discovered_entries([client])
+
+        assert result[0]["skills"][0]["name"] == "invalid-skill"
+        assert result[0]["skills"][0]["files"] == []
+        assert result[0]["skills"][0]["error"]["category"] == "skill_scan_error"
 
     def test_reports_skill_discovery_errors(self):
         client = self._client(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Why: Short-lived Docker Sandboxes can register through Agent Guard before the periodic machine scan runs. Guard discovery currently reports MCP servers but drops discovered skills, leaving the machine inventory incomplete.

How: Include canonical, metadata-only skills in the existing scan-shaped discovery payload, identify the covered component types with `discovery_scope`, and make install/session hooks discover both servers and skills. Full skill contents remain limited to explicit and periodic scans to keep session-start payloads bounded.

Agent Monitor must consume `discovery_scope` and metadata-only skills before this behavior is rolled out.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcb1d44e-3020-4e56-a91d-bcb99340d209?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcb1d44e-3020-4e56-a91d-bcb99340d209&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

