### PR TITLE
feat: report the agent-scan CLI version in the X-User header

### DIFF
--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1764,19 +1764,10 @@ class _CopiedScript(NamedTuple):
     new_checksum: str
 
 
-# The forwarder scripts fence the values install fills in with these markers; the
-# discovery trampolines declare no section and are copied verbatim.
+# The forwarder scripts fence the values install fills in with these markers
 _SECTION_BEGIN = b"# --- BEGIN install-time variables ---"
 _SECTION_END = b"# --- END install-time variables ---"
 
-# A name the scripts can declare and a reader can pick out of the section.
-_VARIABLE_NAME_RE = re.compile(rb"\A__[A-Za-z0-9_]+__\Z")
-
-# Deliberately agent-monitor's ``_CLI_VERSION_RE``
-# (src/agent_monitor/utils/guardrailing_context.py), which degrades anything else to
-# "unknown". A value the platform accepts is also inert inside the double-quoted bash and
-# PowerShell literals the placeholders sit in -- no quote, backslash, ``$``, backtick or
-# newline gets through -- so one check covers both consumers.
 _VARIABLE_VALUE_RE = re.compile(rb"\A[A-Za-z0-9][A-Za-z0-9._+-]{0,63}\Z")
 
 
@@ -1788,19 +1779,18 @@ def _hook_script_variables() -> dict[bytes, bytes]:
     and to the section in both snyk-agent-guard.sh and snyk-agent-guard.ps1; the discovery
     trampolines carry none, as the CLI they exec reports its own version.
 
-    Substituting at install time rather than passing the value through the client's hook
-    config is deliberate: agent-monitor diffs the hook command strings between installs
-    and reports any change as hook tampering, so a value that moves with each release
-    would raise a finding on every machine on every upgrade. Script content is compared
-    against what the previous install wrote, which tracks releases without complaint.
-
-    Every value must be the same for all machines on a given release: a per-machine value
-    would give every machine a different checksum for the same release, ruling out a
-    fleet-wide known-good.
+    Only the values are checked, because only they come from outside this repo: the
+    version is read from the installed distribution's metadata, and lands inside a
+    double-quoted shell literal. The variable names are committed alongside the scripts
+    that declare them, and tests pin the shape of both.
     """
     from agent_scan.version import version_info
 
-    return {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+    variables = {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+    for placeholder, value in variables.items():
+        if not _VARIABLE_VALUE_RE.match(value):
+            raise ValueError(f"Unusable install-time variable value for {placeholder!r}: {value!r}")
+    return variables
 
 
 def _substitute_hook_script_variables(content: bytes) -> bytes:
@@ -1809,23 +1799,23 @@ def _substitute_hook_script_variables(content: bytes) -> bytes:
     Only the section is rewritten. Both forwarders compare their variables against the
     literal placeholder to scrub a copy install never filled in, and the sh script keys
     its curl status readback on a ``__NAME__``-shaped marker; substituting over the whole
-    file would rewrite those. A script that declares no section is returned unchanged.
+    file would rewrite those. A script carrying no complete section -- the trampolines --
+    is returned unchanged.
+
+    The values are checked by ``_hook_script_variables`` before they get here; the markers
+    below are committed alongside the scripts that declare them, and tests pin their shape.
     """
     variables = _hook_script_variables()
-    for placeholder, value in variables.items():
-        if not _VARIABLE_NAME_RE.match(placeholder):
-            raise ValueError(f"Malformed install-time variable name: {placeholder!r}")
-        if not _VARIABLE_VALUE_RE.match(value):
-            raise ValueError(f"Unusable install-time variable value for {placeholder!r}: {value!r}")
 
     begin = content.find(_SECTION_BEGIN)
-    end = content.find(_SECTION_END)
-    if begin < 0 and end < 0:
+    if begin < 0:
         return content
-    if begin < 0 or end < begin:
-        raise ValueError("Hook script declares a malformed install-time variables section")
 
     start = begin + len(_SECTION_BEGIN)
+    end = content.find(_SECTION_END, start)
+    if end < 0:
+        return content
+
     section = content[start:end]
     for placeholder, value in variables.items():
         section = section.replace(placeholder, value)

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1764,18 +1764,39 @@ class _CopiedScript(NamedTuple):
     new_checksum: str
 
 
+def _hook_script_variables() -> dict[bytes, bytes]:
+    """Values substituted into the hook scripts' install-time variables section.
+
+    Keyed by the ``__PLACEHOLDER__`` the scripts declare between their
+    ``--- BEGIN/END install-time variables ---`` markers. To add a variable, add it here
+    and to the section in both snyk-agent-guard.sh and snyk-agent-guard.ps1.
+
+    Substituting at install time rather than passing the value through the client's hook
+    config is deliberate: agent-monitor diffs the hook command strings between installs
+    and reports any change as hook tampering, so a value that moves with each release
+    would raise a finding on every machine on every upgrade. Script content is compared
+    against what the previous install wrote, which tracks releases without complaint.
+
+    Every value must be the same for all machines on a given release, for the same
+    reason -- see the note in the scripts' variables section.
+    """
+    from agent_scan.version import version_info
+
+    return {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+
+
 def _copy_hook_script(dest: Path) -> _CopiedScript:
     """Copy the bundled hook script named ``dest.name`` to *dest*.
 
     Handles both the forwarding hook and the session-start discovery trampoline;
     the bundled resource and the destination share a basename.
     """
-    from agent_scan.version import version_info
-
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     source = importlib_resources.files("agent_scan.hooks").joinpath(dest.name)
-    new_content = source.read_bytes().replace(b"__AGENT_SCAN_VERSION__", version_info.encode())
+    new_content = source.read_bytes()
+    for placeholder, value in _hook_script_variables().items():
+        new_content = new_content.replace(placeholder, value)
     new_checksum = hashlib.sha256(new_content).hexdigest()
 
     current_content = dest.read_bytes() if dest.exists() else None

--- a/src/agent_scan/guard.py
+++ b/src/agent_scan/guard.py
@@ -1764,12 +1764,29 @@ class _CopiedScript(NamedTuple):
     new_checksum: str
 
 
+# The forwarder scripts fence the values install fills in with these markers; the
+# discovery trampolines declare no section and are copied verbatim.
+_SECTION_BEGIN = b"# --- BEGIN install-time variables ---"
+_SECTION_END = b"# --- END install-time variables ---"
+
+# A name the scripts can declare and a reader can pick out of the section.
+_VARIABLE_NAME_RE = re.compile(rb"\A__[A-Za-z0-9_]+__\Z")
+
+# Deliberately agent-monitor's ``_CLI_VERSION_RE``
+# (src/agent_monitor/utils/guardrailing_context.py), which degrades anything else to
+# "unknown". A value the platform accepts is also inert inside the double-quoted bash and
+# PowerShell literals the placeholders sit in -- no quote, backslash, ``$``, backtick or
+# newline gets through -- so one check covers both consumers.
+_VARIABLE_VALUE_RE = re.compile(rb"\A[A-Za-z0-9][A-Za-z0-9._+-]{0,63}\Z")
+
+
 def _hook_script_variables() -> dict[bytes, bytes]:
     """Values substituted into the hook scripts' install-time variables section.
 
     Keyed by the ``__PLACEHOLDER__`` the scripts declare between their
     ``--- BEGIN/END install-time variables ---`` markers. To add a variable, add it here
-    and to the section in both snyk-agent-guard.sh and snyk-agent-guard.ps1.
+    and to the section in both snyk-agent-guard.sh and snyk-agent-guard.ps1; the discovery
+    trampolines carry none, as the CLI they exec reports its own version.
 
     Substituting at install time rather than passing the value through the client's hook
     config is deliberate: agent-monitor diffs the hook command strings between installs
@@ -1777,12 +1794,42 @@ def _hook_script_variables() -> dict[bytes, bytes]:
     would raise a finding on every machine on every upgrade. Script content is compared
     against what the previous install wrote, which tracks releases without complaint.
 
-    Every value must be the same for all machines on a given release, for the same
-    reason -- see the note in the scripts' variables section.
+    Every value must be the same for all machines on a given release: a per-machine value
+    would give every machine a different checksum for the same release, ruling out a
+    fleet-wide known-good.
     """
     from agent_scan.version import version_info
 
     return {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+
+
+def _substitute_hook_script_variables(content: bytes) -> bytes:
+    """Fill in the install-time variables section of a bundled hook script.
+
+    Only the section is rewritten. Both forwarders compare their variables against the
+    literal placeholder to scrub a copy install never filled in, and the sh script keys
+    its curl status readback on a ``__NAME__``-shaped marker; substituting over the whole
+    file would rewrite those. A script that declares no section is returned unchanged.
+    """
+    variables = _hook_script_variables()
+    for placeholder, value in variables.items():
+        if not _VARIABLE_NAME_RE.match(placeholder):
+            raise ValueError(f"Malformed install-time variable name: {placeholder!r}")
+        if not _VARIABLE_VALUE_RE.match(value):
+            raise ValueError(f"Unusable install-time variable value for {placeholder!r}: {value!r}")
+
+    begin = content.find(_SECTION_BEGIN)
+    end = content.find(_SECTION_END)
+    if begin < 0 and end < 0:
+        return content
+    if begin < 0 or end < begin:
+        raise ValueError("Hook script declares a malformed install-time variables section")
+
+    start = begin + len(_SECTION_BEGIN)
+    section = content[start:end]
+    for placeholder, value in variables.items():
+        section = section.replace(placeholder, value)
+    return content[:start] + section + content[end:]
 
 
 def _copy_hook_script(dest: Path) -> _CopiedScript:
@@ -1794,9 +1841,7 @@ def _copy_hook_script(dest: Path) -> _CopiedScript:
     dest.parent.mkdir(parents=True, exist_ok=True)
 
     source = importlib_resources.files("agent_scan.hooks").joinpath(dest.name)
-    new_content = source.read_bytes()
-    for placeholder, value in _hook_script_variables().items():
-        new_content = new_content.replace(placeholder, value)
+    new_content = _substitute_hook_script_variables(source.read_bytes())
     new_checksum = hashlib.sha256(new_content).hexdigest()
 
     current_content = dest.read_bytes() if dest.exists() else None

--- a/src/agent_scan/hook_events.py
+++ b/src/agent_scan/hook_events.py
@@ -77,6 +77,9 @@ def send_hook_event(
             "hostname": hostname,
             "username": get_username(),
             "identifier": machine_id,
+            # The hook scripts read this out of their install-time variables section; here
+            # the running CLI is the sender, so it reports its own version directly.
+            "cli_version": version_info,
         },
         separators=(",", ":"),
     )

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -29,8 +29,29 @@ $ErrorActionPreference = "Stop"
 # Hook API version.
 $VERSION = "2025-11-11"
 
-# Agent-scan CLI version (replaced at install time).
+# Install-time variables.
+#
+# `agent-scan guard install` substitutes each __PLACEHOLDER__ between the markers below as
+# it copies this script into place (_hook_script_variables in guard.py). Always read them
+# through Get-ScriptVar: this script also runs straight from the source tree, and a copy
+# written by an older CLI will not know about variables added later, so a placeholder can
+# survive. Keep the markers around declarations only -- the tests treat anything
+# placeholder-shaped left between them as a substitution that install forgot.
+#
+# Keep these per-release, never per-machine. agent-monitor's tamper detection compares the
+# installed script's checksum between installs, and a per-machine value would give every
+# machine a different checksum for the same release.
+# --- BEGIN install-time variables ---
 $AGENT_SCAN_VERSION = "__AGENT_SCAN_VERSION__"
+# --- END install-time variables ---
+
+# Value of an install-time variable, or "unknown" when its placeholder was not substituted.
+# The literal placeholder is worse than nothing on the wire: agent-monitor rejects it as a
+# version anyway, and it would read as a real value everywhere else.
+function Get-ScriptVar($value) {
+    if (-not $value -or $value -match '^__[A-Za-z0-9_]+__$') { return "unknown" }
+    return $value
+}
 
 # ---------------------------------------------------------------------------
 # Main
@@ -67,7 +88,8 @@ switch ($Client) {
     }
 }
 
-$userAgent = "snyk/snyk-agent-guard.ps1 Agent Scan v$AGENT_SCAN_VERSION"
+$cliVersion = Get-ScriptVar $AGENT_SCAN_VERSION
+$userAgent = "snyk/snyk-agent-guard.ps1 Agent Scan v$cliVersion"
 $url = "${RemoteUrl}${endpoint}?version=$VERSION"
 
 # Read payload from stdin as UTF-8 (strips BOM automatically)
@@ -97,8 +119,8 @@ function JsonEscape($s) {
     return $s
 }
 
-$xUser = '{{"hostname":"{0}","username":"{1}","identifier":"{2}"}}' -f `
-    (JsonEscape $hostname), (JsonEscape $username), (JsonEscape $MachineId)
+$xUser = '{{"hostname":"{0}","username":"{1}","identifier":"{2}","cli_version":"{3}"}}' -f `
+    (JsonEscape $hostname), (JsonEscape $username), (JsonEscape $MachineId), (JsonEscape $cliVersion)
 
 # Execute request
 try {

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -26,13 +26,13 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# Hook API version.
-$VERSION = "2025-11-11"
-
 # --- BEGIN install-time variables ---
 # Agent-scan CLI version (replaced at install time).
 $AGENT_SCAN_VERSION = "__AGENT_SCAN_VERSION__"
 # --- END install-time variables ---
+
+# Hook API version.
+$VERSION = "2025-11-11"
 
 # ---------------------------------------------------------------------------
 # Main

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -29,25 +29,11 @@ $ErrorActionPreference = "Stop"
 # Hook API version.
 $VERSION = "2025-11-11"
 
-# Install-time variables.
-#
-# `agent-scan guard install` substitutes each __PLACEHOLDER__ between the markers below as
-# it copies this script into place (_hook_script_variables in guard.py). Always read them
-# through Get-ScriptVar: this script also runs straight from the source tree, and a copy
-# written by an older CLI will not know about variables added later, so a placeholder can
-# survive. Keep the markers around declarations only -- the tests treat anything
-# placeholder-shaped left between them as a substitution that install forgot.
-#
-# Keep these per-release, never per-machine. agent-monitor's tamper detection compares the
-# installed script's checksum between installs, and a per-machine value would give every
-# machine a different checksum for the same release.
 # --- BEGIN install-time variables ---
+# Agent-scan CLI version (replaced at install time).
 $AGENT_SCAN_VERSION = "__AGENT_SCAN_VERSION__"
 # --- END install-time variables ---
 
-# Value of an install-time variable, or "unknown" when its placeholder was not substituted.
-# The literal placeholder is worse than nothing on the wire: agent-monitor rejects it as a
-# version anyway, and it would read as a real value everywhere else.
 function Get-ScriptVar($value) {
     if (-not $value -or $value -match '^__[A-Za-z0-9_]+__$') { return "unknown" }
     return $value

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -34,11 +34,6 @@ $VERSION = "2025-11-11"
 $AGENT_SCAN_VERSION = "__AGENT_SCAN_VERSION__"
 # --- END install-time variables ---
 
-function Get-ScriptVar($value) {
-    if (-not $value -or $value -match '^__[A-Za-z0-9_]+__$') { return "unknown" }
-    return $value
-}
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -74,7 +69,13 @@ switch ($Client) {
     }
 }
 
-$cliVersion = Get-ScriptVar $AGENT_SCAN_VERSION
+$cliVersion = $AGENT_SCAN_VERSION
+# Only a copy install never filled in still holds the placeholder, and the literal must
+# not reach the wire. This sits outside the variables section on purpose: substituting
+# over it would rewrite the very literal it tests for.
+if ($cliVersion -eq '__AGENT_SCAN_VERSION__') {
+    $cliVersion = "unknown"
+}
 $userAgent = "snyk/snyk-agent-guard.ps1 Agent Scan v$cliVersion"
 $url = "${RemoteUrl}${endpoint}?version=$VERSION"
 
@@ -95,13 +96,15 @@ $body = "base64:$encoded"
 $hostname = try { [System.Net.Dns]::GetHostName() } catch { "unknown" }
 $username = try { [System.Environment]::UserName } catch { "unknown" }
 
-# Minimal JSON escaping
+# Minimal JSON escaping. String.Replace, not -replace: the latter reads its pattern as a
+# regex, so escaping the escape character through it doubles every backslash again.
 function JsonEscape($s) {
-    $s = $s -replace '\\', '\\\\'
-    $s = $s -replace '"', '\"'
-    $s = $s -replace "`t", '\t'
-    $s = $s -replace "`r", '\r'
-    $s = $s -replace "`n", '\n'
+    $s = [string]$s
+    $s = $s.Replace('\', '\\')
+    $s = $s.Replace('"', '\"')
+    $s = $s.Replace("`t", '\t')
+    $s = $s.Replace("`r", '\r')
+    $s = $s.Replace("`n", '\n')
     return $s
 }
 

--- a/src/agent_scan/hooks/snyk-agent-guard.ps1
+++ b/src/agent_scan/hooks/snyk-agent-guard.ps1
@@ -96,15 +96,13 @@ $body = "base64:$encoded"
 $hostname = try { [System.Net.Dns]::GetHostName() } catch { "unknown" }
 $username = try { [System.Environment]::UserName } catch { "unknown" }
 
-# Minimal JSON escaping. String.Replace, not -replace: the latter reads its pattern as a
-# regex, so escaping the escape character through it doubles every backslash again.
+# Minimal JSON escaping
 function JsonEscape($s) {
-    $s = [string]$s
-    $s = $s.Replace('\', '\\')
-    $s = $s.Replace('"', '\"')
-    $s = $s.Replace("`t", '\t')
-    $s = $s.Replace("`r", '\r')
-    $s = $s.Replace("`n", '\n')
+    $s = $s -replace '\\', '\\\\'
+    $s = $s -replace '"', '\"'
+    $s = $s -replace "`t", '\t'
+    $s = $s -replace "`r", '\r'
+    $s = $s -replace "`n", '\n'
     return $s
 }
 

--- a/src/agent_scan/hooks/snyk-agent-guard.sh
+++ b/src/agent_scan/hooks/snyk-agent-guard.sh
@@ -14,13 +14,13 @@
 #
 set -euo pipefail
 
-# Hook API version.
-VERSION="2025-11-11"
-
 # --- BEGIN install-time variables ---
 # Agent-scan CLI version (replaced at install time).
 AGENT_SCAN_VERSION="__AGENT_SCAN_VERSION__"
 # --- END install-time variables ---
+
+# Hook API version.
+VERSION="2025-11-11"
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/src/agent_scan/hooks/snyk-agent-guard.sh
+++ b/src/agent_scan/hooks/snyk-agent-guard.sh
@@ -45,13 +45,6 @@ json_quote() {
   printf '"%s"' "$(json_escape "${1:-}")"
 }
 
-script_var() {
-  case "${1-}" in
-    ""|__*__) printf '%s' "unknown" ;;
-    *) printf '%s' "$1" ;;
-  esac
-}
-
 get_hostname() {
   if [[ -n "${HOSTNAME:-}" ]]; then
     printf '%s' "$HOSTNAME"
@@ -100,7 +93,13 @@ hook_main() {
   [[ -n "${MACHINE_ID:-}" ]] || die "MACHINE_ID environment variable is not set"
 
   local cli_version user_agent
-  cli_version="$(script_var "$AGENT_SCAN_VERSION")"
+  cli_version="$AGENT_SCAN_VERSION"
+  # Only a copy install never filled in still holds the placeholder, and the literal must
+  # not reach the wire. This sits outside the variables section on purpose: substituting
+  # over it would rewrite the very literal it tests for.
+  if [[ "$cli_version" == "__AGENT_SCAN_VERSION__" ]]; then
+    cli_version="unknown"
+  fi
   user_agent="snyk/snyk-agent-guard.sh Agent Scan v${cli_version}"
 
   # Determine endpoint based on client

--- a/src/agent_scan/hooks/snyk-agent-guard.sh
+++ b/src/agent_scan/hooks/snyk-agent-guard.sh
@@ -17,8 +17,21 @@ set -euo pipefail
 # Hook API version.
 VERSION="2025-11-11"
 
-# Agent-scan CLI version (replaced at install time).
+# Install-time variables.
+#
+# `agent-scan guard install` substitutes each __PLACEHOLDER__ between the markers below as
+# it copies this script into place (_hook_script_variables in guard.py). Always read them
+# through script_var: this script also runs straight from the source tree, and a copy
+# written by an older CLI will not know about variables added later, so a placeholder can
+# survive. Keep the markers around declarations only -- the tests treat anything
+# placeholder-shaped left between them as a substitution that install forgot.
+#
+# Keep these per-release, never per-machine. agent-monitor's tamper detection compares the
+# installed script's checksum between installs, and a per-machine value would give every
+# machine a different checksum for the same release.
+# --- BEGIN install-time variables ---
 AGENT_SCAN_VERSION="__AGENT_SCAN_VERSION__"
+# --- END install-time variables ---
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -41,6 +54,16 @@ json_escape() {
 
 json_quote() {
   printf '"%s"' "$(json_escape "${1:-}")"
+}
+
+# Value of an install-time variable, or "unknown" when its placeholder was not substituted.
+# The literal placeholder is worse than nothing on the wire: agent-monitor rejects it as a
+# version anyway, and it would read as a real value everywhere else.
+script_var() {
+  case "${1-}" in
+    ""|__*__) printf '%s' "unknown" ;;
+    *) printf '%s' "$1" ;;
+  esac
 }
 
 get_hostname() {
@@ -90,21 +113,16 @@ hook_main() {
   [[ -n "$pushkey" ]] || die "PUSH_KEY environment variable is not set"
   [[ -n "${MACHINE_ID:-}" ]] || die "MACHINE_ID environment variable is not set"
 
-  # Determine endpoint and user-agent based on client
-  local endpoint user_agent
+  local cli_version user_agent
+  cli_version="$(script_var "$AGENT_SCAN_VERSION")"
+  user_agent="snyk/snyk-agent-guard.sh Agent Scan v${cli_version}"
+
+  # Determine endpoint based on client
+  local endpoint
   case "$client" in
-    claude-code)
-      endpoint="/hidden/agent-monitor/hooks/claude-code"
-      user_agent="snyk/snyk-agent-guard.sh Agent Scan v${AGENT_SCAN_VERSION}"
-      ;;
-    cursor)
-      endpoint="/hidden/agent-monitor/hooks/cursor"
-      user_agent="snyk/snyk-agent-guard.sh Agent Scan v${AGENT_SCAN_VERSION}"
-      ;;
-    codex)
-      endpoint="/hidden/agent-monitor/hooks/codex"
-      user_agent="snyk/snyk-agent-guard.sh Agent Scan v${AGENT_SCAN_VERSION}"
-      ;;
+    claude-code) endpoint="/hidden/agent-monitor/hooks/claude-code" ;;
+    cursor) endpoint="/hidden/agent-monitor/hooks/cursor" ;;
+    codex) endpoint="/hidden/agent-monitor/hooks/codex" ;;
     *) die "Unknown client: ${client}. Expected claude-code, cursor, or codex." ;;
   esac
 
@@ -127,10 +145,11 @@ hook_main() {
   hostname="$(get_hostname)"
   username="$(get_username)"
 
-  x_user="$(printf '{%s:%s,%s:%s,%s:%s}' \
+  x_user="$(printf '{%s:%s,%s:%s,%s:%s,%s:%s}' \
     "\"hostname\"" "$(json_quote "$hostname")" \
     "\"username\"" "$(json_quote "$username")" \
-    "\"identifier\"" "$(json_quote "$MACHINE_ID")")"
+    "\"identifier\"" "$(json_quote "$MACHINE_ID")" \
+    "\"cli_version\"" "$(json_quote "$cli_version")")"
 
   # Execute request
   local resp body http_code marker

--- a/src/agent_scan/hooks/snyk-agent-guard.sh
+++ b/src/agent_scan/hooks/snyk-agent-guard.sh
@@ -17,19 +17,8 @@ set -euo pipefail
 # Hook API version.
 VERSION="2025-11-11"
 
-# Install-time variables.
-#
-# `agent-scan guard install` substitutes each __PLACEHOLDER__ between the markers below as
-# it copies this script into place (_hook_script_variables in guard.py). Always read them
-# through script_var: this script also runs straight from the source tree, and a copy
-# written by an older CLI will not know about variables added later, so a placeholder can
-# survive. Keep the markers around declarations only -- the tests treat anything
-# placeholder-shaped left between them as a substitution that install forgot.
-#
-# Keep these per-release, never per-machine. agent-monitor's tamper detection compares the
-# installed script's checksum between installs, and a per-machine value would give every
-# machine a different checksum for the same release.
 # --- BEGIN install-time variables ---
+# Agent-scan CLI version (replaced at install time).
 AGENT_SCAN_VERSION="__AGENT_SCAN_VERSION__"
 # --- END install-time variables ---
 
@@ -56,9 +45,6 @@ json_quote() {
   printf '"%s"' "$(json_escape "${1:-}")"
 }
 
-# Value of an install-time variable, or "unknown" when its placeholder was not substituted.
-# The literal placeholder is worse than nothing on the wire: agent-monitor rejects it as a
-# version anyway, and it would read as a real value everywhere else.
 script_var() {
   case "${1-}" in
     ""|__*__) printf '%s' "unknown" ;;

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -65,6 +66,7 @@ from agent_scan.guard import (
 from agent_scan.models import ClientToInspect, InspectedPath, InspectedServer, RemoteServer, StdioServer
 from agent_scan.models.errors import CouldNotParseMCPConfig, FileNotFoundConfig
 from agent_scan.pushkeys import GuardEnabledAccessDeniedError
+from agent_scan.version import version_info
 
 # ---------------------------------------------------------------------------
 # Helpers to build hook data
@@ -2892,6 +2894,64 @@ class TestCodexManagedRequirementsToml:
         assert diff["removed"]
 
 
+# ===================================================================
+# Install-time variables section of the forwarder scripts
+# ===================================================================
+
+
+# agent-monitor accepts a cli_version only in this shape and silently degrades anything
+# else to "unknown" (GuardrailingContext.get_cli_version / _CLI_VERSION_RE in
+# agent-monitor's src/agent_monitor/utils/guardrailing_context.py). Pinned here so a
+# version scheme the platform would drop fails on our side, where it is fixable.
+_AGENT_MONITOR_CLI_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
+
+_FORWARDER_SCRIPTS = ("snyk-agent-guard.sh", "snyk-agent-guard.ps1")
+
+# Both scripts fence their install-time variables with these markers. Only the tests read
+# them -- install substitutes over the whole file -- so they live here rather than in
+# guard.py, where they would be a constant nothing in the product uses.
+_SECTION_BEGIN = "# --- BEGIN install-time variables ---"
+_SECTION_END = "# --- END install-time variables ---"
+
+
+def _variables_section(text: str) -> str:
+    """Return the body between the scripts' install-time variables markers."""
+    assert _SECTION_BEGIN in text
+    assert _SECTION_END in text
+    return text.split(_SECTION_BEGIN, 1)[1].split(_SECTION_END, 1)[0]
+
+
+class TestHookScriptInstallTimeVariables:
+    """Both forwarder scripts carry a variables section that install fills in."""
+
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_bundled_section_holds_the_version_placeholder(self, name):
+        section = _variables_section(_get_script_path(name).read_text())
+
+        assert "__AGENT_SCAN_VERSION__" in section
+
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_copy_substitutes_the_whole_section(self, tmp_path, name):
+        dest = tmp_path / "hooks" / name
+        guard_module._copy_hook_script(dest)
+
+        section = _variables_section(dest.read_text())
+        assert f'"{version_info}"' in section
+        # A placeholder left unsubstituted travels to the platform as a literal, so the
+        # rendered section must hold no `__NAME__` -- including variables added later.
+        assert not re.search(r"__[A-Za-z0-9_]+__", section)
+
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_every_placeholder_in_the_section_has_a_substitution(self, name):
+        section = _variables_section(_get_script_path(name).read_text())
+
+        declared = set(re.findall(r"__[A-Za-z0-9_]+__", section))
+        assert declared == {key.decode() for key in guard_module._hook_script_variables()}
+
+    def test_emitted_version_matches_the_shape_agent_monitor_accepts(self):
+        assert _AGENT_MONITOR_CLI_VERSION_RE.fullmatch(version_info)
+
+
 @pytest.mark.skipif(IS_WINDOWS, reason="bash script; skipped on Windows")
 class TestBashHookScript:
     """Integration: invoke the real .sh script against a local HTTP server."""
@@ -3012,6 +3072,56 @@ class TestBashHookScript:
         assert result.returncode == 0, result.stderr
         x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
         assert x_user["identifier"] == "machine-42"
+
+    def test_installed_script_reports_its_cli_version(self, tmp_path, hook_server):
+        script = tmp_path / "hooks" / "snyk-agent-guard.sh"
+        guard_module._copy_hook_script(script)
+
+        result = subprocess.run(
+            ["bash", str(script), "--client", "claude-code"],
+            input='{"hook_event_name":"test","session_id":"s1"}',
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "PUSH_KEY": "test-pk",
+                "REMOTE_HOOKS_BASE_URL": hook_server,
+                "MACHINE_ID": "machine-42",
+            },
+        )
+
+        assert result.returncode == 0, result.stderr
+        req = _HookHandler.last_request
+        assert json.loads(req["headers"]["X-User"])["cli_version"] == version_info
+        assert req["headers"]["User-Agent"].endswith(f"Agent Scan v{version_info}")
+
+    def test_uninstalled_script_reports_an_unknown_cli_version(self, hook_server):
+        """Run from the source tree the placeholder survives -- it must not reach the wire.
+
+        The same holds for a copy written by a CLI that predates a variable: agent-monitor
+        would reject the literal anyway, and an unparseable value is worse than ``unknown``.
+        """
+        script = _get_script_path("snyk-agent-guard.sh")
+
+        result = subprocess.run(
+            ["bash", str(script), "--client", "claude-code"],
+            input='{"hook_event_name":"test","session_id":"s1"}',
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "PUSH_KEY": "test-pk",
+                "REMOTE_HOOKS_BASE_URL": hook_server,
+                "MACHINE_ID": "machine-42",
+            },
+        )
+
+        assert result.returncode == 0, result.stderr
+        req = _HookHandler.last_request
+        assert json.loads(req["headers"]["X-User"])["cli_version"] == "unknown"
+        assert "__AGENT_SCAN_VERSION__" not in req["headers"]["User-Agent"]
 
     def test_missing_machine_id_fails(self, hook_server):
         script = _get_script_path("snyk-agent-guard.sh")
@@ -3285,6 +3395,64 @@ class TestPowerShellHookScript:
         assert result.returncode == 0, result.stderr
         x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
         assert x_user["identifier"] == "machine-42"
+
+    def test_installed_script_reports_its_cli_version(self, tmp_path, hook_server):
+        script = tmp_path / "hooks" / "snyk-agent-guard.ps1"
+        guard_module._copy_hook_script(script)
+
+        result = subprocess.run(
+            [
+                self._ps_cmd(),
+                "-File",
+                str(script),
+                "-Client",
+                "claude-code",
+                "-PushKey",
+                "test-pk",
+                "-RemoteUrl",
+                hook_server,
+                "-MachineId",
+                "machine-42",
+            ],
+            input='{"hook_event_name":"test","session_id":"s1"}',
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        req = _HookHandler.last_request
+        assert json.loads(req["headers"]["X-User"])["cli_version"] == version_info
+        assert req["headers"]["User-Agent"].endswith(f"Agent Scan v{version_info}")
+
+    def test_uninstalled_script_reports_an_unknown_cli_version(self, hook_server):
+        """The POSIX contract, pinned on Windows: an unsubstituted placeholder never ships."""
+        script = _get_script_path("snyk-agent-guard.ps1")
+
+        result = subprocess.run(
+            [
+                self._ps_cmd(),
+                "-File",
+                str(script),
+                "-Client",
+                "claude-code",
+                "-PushKey",
+                "test-pk",
+                "-RemoteUrl",
+                hook_server,
+                "-MachineId",
+                "machine-42",
+            ],
+            input='{"hook_event_name":"test","session_id":"s1"}',
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        req = _HookHandler.last_request
+        assert json.loads(req["headers"]["X-User"])["cli_version"] == "unknown"
+        assert "__AGENT_SCAN_VERSION__" not in req["headers"]["User-Agent"]
 
     def test_missing_machine_id_fails(self, hook_server):
         script = _get_script_path("snyk-agent-guard.ps1")

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -19,6 +19,7 @@ from unittest.mock import call as mock_call
 import pytest
 
 import agent_scan.guard as guard_module
+import agent_scan.version as version_module
 from agent_scan.guard import (
     _PERMISSION_DENIED,
     ALL_CLIENTS,
@@ -2954,6 +2955,28 @@ class TestHookScriptInstallTimeVariables:
         assert "__AGENT_SCAN_VERSION__" in section
 
     @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_bundled_section_is_well_formed(self, name):
+        """Substitution trusts these markers, so the committed scripts have to declare them.
+
+        One BEGIN ahead of one END. A script declaring them any other way has no section
+        install can find, and would be copied with its placeholders intact.
+        """
+        text = _get_script_path(name).read_text()
+
+        assert text.count(_SECTION_BEGIN) == 1
+        assert text.count(_SECTION_END) == 1
+        assert text.index(_SECTION_BEGIN) < text.index(_SECTION_END)
+
+    def test_shipped_variable_names_are_placeholder_shaped(self):
+        """``__NAME__`` is what makes a variable unambiguous inside the section.
+
+        Substitution is a plain replace over the section body, so a name of any other
+        shape could match ordinary script text and rewrite it.
+        """
+        for placeholder in guard_module._hook_script_variables():
+            assert _PLACEHOLDER_RE.fullmatch(placeholder.decode())
+
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
     def test_copy_substitutes_the_whole_section(self, tmp_path, name):
         dest = tmp_path / "hooks" / name
         guard_module._copy_hook_script(dest)
@@ -3000,18 +3023,8 @@ class TestHookScriptInstallTimeVariables:
             assert placeholder.decode() in head + tail
 
 
-class TestHookScriptVariableSubstitution:
-    """What install writes into the section is checked before it lands."""
-
-    _SCRIPT = b"".join(
-        (
-            b'head "__X__"\n',
-            guard_module._SECTION_BEGIN,
-            b'\nV="__X__"\n',
-            guard_module._SECTION_END,
-            b'\ntail "__X__"\n',
-        )
-    )
+class TestHookScriptVariableValues:
+    """What install would write into the section is checked before it is handed out."""
 
     # Shapes a release can plausibly produce, all inert inside the double-quoted shell
     # literal they land in.
@@ -3034,48 +3047,77 @@ class TestHookScriptVariableSubstitution:
 
     @pytest.mark.parametrize("value", _ACCEPTED)
     def test_accepts_a_release_shaped_value(self, monkeypatch, value):
-        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__X__": value.encode()})
+        monkeypatch.setattr(version_module, "version_info", value)
 
-        rendered = guard_module._substitute_hook_script_variables(self._SCRIPT)
-
-        assert f'V="{value}"'.encode() in rendered
+        assert guard_module._hook_script_variables() == {b"__AGENT_SCAN_VERSION__": value.encode()}
         # Both consumers have to accept it: the shell that parses the script, and
         # agent-monitor, which degrades anything outside its shape to "unknown".
         assert _AGENT_MONITOR_CLI_VERSION_RE.fullmatch(value)
 
     @pytest.mark.parametrize("value", _REJECTED)
     def test_rejects_a_value_the_shell_or_the_platform_would_mangle(self, monkeypatch, value):
-        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__X__": value.encode()})
+        monkeypatch.setattr(version_module, "version_info", value)
 
         with pytest.raises(ValueError, match="install-time"):
-            guard_module._substitute_hook_script_variables(self._SCRIPT)
+            guard_module._hook_script_variables()
 
         assert not _AGENT_MONITOR_CLI_VERSION_RE.fullmatch(value)
 
-    def test_rejects_a_placeholder_the_scripts_could_not_declare(self, monkeypatch):
-        """A name outside `__NAME__` is one the section tests above would not find."""
-        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__PUSH-KEY__": b"0.6.2"})
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_install_fails_rather_than_writing_an_unusable_value(self, monkeypatch, tmp_path, name):
+        """The check gates the copy, so a rejected value never reaches a hook script."""
+        monkeypatch.setattr(version_module, "version_info", '0.6.2"; id; x="')
+        dest = tmp_path / "hooks" / name
 
         with pytest.raises(ValueError, match="install-time"):
-            guard_module._substitute_hook_script_variables(self._SCRIPT)
+            guard_module._copy_hook_script(dest)
+
+        assert not dest.exists()
+
+    def test_the_shipped_variables_are_the_cli_version(self):
+        """The sentinel-driven tests prove the plumbing; this pins what actually ships."""
+        assert guard_module._hook_script_variables() == {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+
+
+class TestHookScriptVariableSubstitution:
+    """Only the section is rewritten, with whatever the variables mapping holds."""
+
+    _SCRIPT = b"".join(
+        (
+            b'head "__X__"\n',
+            guard_module._SECTION_BEGIN,
+            b'\nV="__X__"\n',
+            guard_module._SECTION_END,
+            b'\ntail "__X__"\n',
+        )
+    )
 
     def test_substitutes_only_inside_the_section(self, monkeypatch):
         monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__X__": b"0.6.2"})
 
         rendered = guard_module._substitute_hook_script_variables(self._SCRIPT)
 
+        assert b'V="0.6.2"' in rendered
         assert rendered.count(b"__X__") == 2
         assert rendered.startswith(b'head "__X__"\n')
         assert rendered.endswith(b'tail "__X__"\n')
 
-    @pytest.mark.parametrize("content", [_SCRIPT.split(_SECTION_END.encode())[0], guard_module._SECTION_END])
-    def test_a_half_declared_section_fails_loudly(self, content):
-        with pytest.raises(ValueError, match="install-time"):
-            guard_module._substitute_hook_script_variables(content)
+    @pytest.mark.parametrize(
+        "content",
+        [
+            _SCRIPT.split(_SECTION_END.encode())[0],
+            guard_module._SECTION_END,
+            guard_module._SECTION_END + guard_module._SECTION_BEGIN,
+        ],
+    )
+    def test_only_a_complete_section_is_rewritten(self, content):
+        """Anything short of a BEGIN-then-END pair leaves the script as it was.
 
-    def test_the_shipped_variables_are_the_cli_version(self):
-        """The sentinel-driven tests prove the plumbing; this pins what actually ships."""
-        assert guard_module._hook_script_variables() == {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+        What the forwarders ship is pinned against the markers elsewhere. One that lost
+        its section keeps its placeholder, which the script's own fallback scrubs at hook
+        time rather than reporting it as a version.
+        """
+        assert guard_module._substitute_hook_script_variables(content) == content
 
     @pytest.mark.parametrize("name", _TRAMPOLINE_SCRIPTS)
     def test_trampolines_carry_no_install_time_variables(self, tmp_path, name):

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -2906,19 +2906,42 @@ class TestCodexManagedRequirementsToml:
 _AGENT_MONITOR_CLI_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
 
 _FORWARDER_SCRIPTS = ("snyk-agent-guard.sh", "snyk-agent-guard.ps1")
+_TRAMPOLINE_SCRIPTS = ("snyk-agent-guard-discover.sh", "snyk-agent-guard-discover.ps1")
 
-# Both scripts fence their install-time variables with these markers. Only the tests read
-# them -- install substitutes over the whole file -- so they live here rather than in
-# guard.py, where they would be a constant nothing in the product uses.
-_SECTION_BEGIN = "# --- BEGIN install-time variables ---"
-_SECTION_END = "# --- END install-time variables ---"
+_SECTION_BEGIN = guard_module._SECTION_BEGIN.decode()
+_SECTION_END = guard_module._SECTION_END.decode()
+
+_PLACEHOLDER_RE = re.compile(r"__[A-Za-z0-9_]+__")
+
+
+def _split_on_section(text: str) -> tuple[str, str, str]:
+    """Split *text* around the install-time variables markers into head, body, tail."""
+    assert _SECTION_BEGIN in text
+    assert _SECTION_END in text
+    head, rest = text.split(_SECTION_BEGIN, 1)
+    section, tail = rest.split(_SECTION_END, 1)
+    return head, section, tail
 
 
 def _variables_section(text: str) -> str:
     """Return the body between the scripts' install-time variables markers."""
-    assert _SECTION_BEGIN in text
-    assert _SECTION_END in text
-    return text.split(_SECTION_BEGIN, 1)[1].split(_SECTION_END, 1)[0]
+    return _split_on_section(text)[1]
+
+
+# ``version_info`` is "unknown" wherever the distribution metadata is unresolvable, which
+# is also what the scripts report for a placeholder install never filled in. Asserting a
+# sentinel instead keeps the installed/uninstalled pair apart in such an environment.
+_SENTINEL_VERSION = "9.9.9-test"
+
+
+def _copy_with_sentinel_version(monkeypatch, dest: Path) -> None:
+    """Install *dest* carrying a version no fallback could have produced."""
+    monkeypatch.setattr(
+        guard_module,
+        "_hook_script_variables",
+        lambda: {b"__AGENT_SCAN_VERSION__": _SENTINEL_VERSION.encode()},
+    )
+    guard_module._copy_hook_script(dest)
 
 
 class TestHookScriptInstallTimeVariables:
@@ -2939,17 +2962,137 @@ class TestHookScriptInstallTimeVariables:
         assert f'"{version_info}"' in section
         # A placeholder left unsubstituted travels to the platform as a literal, so the
         # rendered section must hold no `__NAME__` -- including variables added later.
-        assert not re.search(r"__[A-Za-z0-9_]+__", section)
+        assert not _PLACEHOLDER_RE.search(section)
+
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_copy_leaves_everything_outside_the_section_untouched(self, tmp_path, name):
+        """Install rewrites the section and nothing else.
+
+        The scripts hold `__NAME__`-shaped literals outside the section -- the fallbacks
+        below, and the sh script's curl status marker. A substitution that reached them
+        would silently change what the script does.
+        """
+        dest = tmp_path / "hooks" / name
+        guard_module._copy_hook_script(dest)
+
+        bundled_head, _, bundled_tail = _split_on_section(_get_script_path(name).read_text())
+        head, _, tail = _split_on_section(dest.read_text())
+
+        assert (head, tail) == (bundled_head, bundled_tail)
 
     @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
     def test_every_placeholder_in_the_section_has_a_substitution(self, name):
         section = _variables_section(_get_script_path(name).read_text())
 
-        declared = set(re.findall(r"__[A-Za-z0-9_]+__", section))
+        declared = set(_PLACEHOLDER_RE.findall(section))
         assert declared == {key.decode() for key in guard_module._hook_script_variables()}
 
-    def test_emitted_version_matches_the_shape_agent_monitor_accepts(self):
-        assert _AGENT_MONITOR_CLI_VERSION_RE.fullmatch(version_info)
+    @pytest.mark.parametrize("name", _FORWARDER_SCRIPTS)
+    def test_every_placeholder_has_a_fallback_outside_the_section(self, name):
+        """Each script scrubs a variable install never filled in.
+
+        The comparison is against the literal placeholder, so it has to sit outside the
+        section: substituting over it would rewrite the very literal it tests for.
+        """
+        head, _, tail = _split_on_section(_get_script_path(name).read_text())
+
+        for placeholder in guard_module._hook_script_variables():
+            assert placeholder.decode() in head + tail
+
+
+class TestHookScriptVariableSubstitution:
+    """What install writes into the section is checked before it lands."""
+
+    _SCRIPT = b"".join(
+        (
+            b'head "__X__"\n',
+            guard_module._SECTION_BEGIN,
+            b'\nV="__X__"\n',
+            guard_module._SECTION_END,
+            b'\ntail "__X__"\n',
+        )
+    )
+
+    # Shapes a release can plausibly produce, all inert inside the double-quoted shell
+    # literal they land in.
+    _ACCEPTED = ("0.6.2", "0.6.2+g1234f00", "1.2.3.dev0", "unknown", "1")
+
+    # Values that would break the rendered script, execute at hook time, or reach the
+    # platform as something it drops.
+    _REJECTED = (
+        "",
+        '0.6.2"; id; x="',
+        "$(id)",
+        "`id`",
+        "back\\slash",
+        "two\nlines",
+        "with space",
+        "1!2.0",
+        "_leading",
+        "a" * 65,
+    )
+
+    @pytest.mark.parametrize("value", _ACCEPTED)
+    def test_accepts_a_release_shaped_value(self, monkeypatch, value):
+        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__X__": value.encode()})
+
+        rendered = guard_module._substitute_hook_script_variables(self._SCRIPT)
+
+        assert f'V="{value}"'.encode() in rendered
+        # Both consumers have to accept it: the shell that parses the script, and
+        # agent-monitor, which degrades anything outside its shape to "unknown".
+        assert _AGENT_MONITOR_CLI_VERSION_RE.fullmatch(value)
+
+    @pytest.mark.parametrize("value", _REJECTED)
+    def test_rejects_a_value_the_shell_or_the_platform_would_mangle(self, monkeypatch, value):
+        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__X__": value.encode()})
+
+        with pytest.raises(ValueError, match="install-time"):
+            guard_module._substitute_hook_script_variables(self._SCRIPT)
+
+        assert not _AGENT_MONITOR_CLI_VERSION_RE.fullmatch(value)
+
+    def test_rejects_a_placeholder_the_scripts_could_not_declare(self, monkeypatch):
+        """A name outside `__NAME__` is one the section tests above would not find."""
+        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__PUSH-KEY__": b"0.6.2"})
+
+        with pytest.raises(ValueError, match="install-time"):
+            guard_module._substitute_hook_script_variables(self._SCRIPT)
+
+    def test_substitutes_only_inside_the_section(self, monkeypatch):
+        monkeypatch.setattr(guard_module, "_hook_script_variables", lambda: {b"__X__": b"0.6.2"})
+
+        rendered = guard_module._substitute_hook_script_variables(self._SCRIPT)
+
+        assert rendered.count(b"__X__") == 2
+        assert rendered.startswith(b'head "__X__"\n')
+        assert rendered.endswith(b'tail "__X__"\n')
+
+    @pytest.mark.parametrize("content", [_SCRIPT.split(_SECTION_END.encode())[0], guard_module._SECTION_END])
+    def test_a_half_declared_section_fails_loudly(self, content):
+        with pytest.raises(ValueError, match="install-time"):
+            guard_module._substitute_hook_script_variables(content)
+
+    def test_the_shipped_variables_are_the_cli_version(self):
+        """The sentinel-driven tests prove the plumbing; this pins what actually ships."""
+        assert guard_module._hook_script_variables() == {b"__AGENT_SCAN_VERSION__": version_info.encode()}
+
+    @pytest.mark.parametrize("name", _TRAMPOLINE_SCRIPTS)
+    def test_trampolines_carry_no_install_time_variables(self, tmp_path, name):
+        """The trampolines exec the CLI, which reports its own version directly.
+
+        They declare no section, so install has nothing to fill in and copies them
+        verbatim. A variable one of them ever needs has to be declared here first.
+        """
+        bundled = _get_script_path(name).read_bytes()
+        assert guard_module._SECTION_BEGIN not in bundled
+        assert guard_module._SECTION_END not in bundled
+        assert not _PLACEHOLDER_RE.search(bundled.decode())
+
+        dest = tmp_path / "hooks" / name
+        guard_module._copy_hook_script(dest)
+
+        assert dest.read_bytes() == bundled
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="bash script; skipped on Windows")
@@ -3073,9 +3216,32 @@ class TestBashHookScript:
         x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
         assert x_user["identifier"] == "machine-42"
 
-    def test_installed_script_reports_its_cli_version(self, tmp_path, hook_server):
+    def test_machine_id_survives_json_escaping(self, hook_server):
+        """The platform keys machine identity on this value, so it must round-trip."""
+        script = _get_script_path("snyk-agent-guard.sh")
+        machine_id = 'DOMAIN\\host"x\tz'
+
+        result = subprocess.run(
+            ["bash", str(script), "--client", "claude-code"],
+            input='{"hook_event_name":"test","session_id":"s1"}',
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={
+                "PATH": "/usr/bin:/bin:/usr/local/bin",
+                "PUSH_KEY": "test-pk",
+                "REMOTE_HOOKS_BASE_URL": hook_server,
+                "MACHINE_ID": machine_id,
+            },
+        )
+
+        assert result.returncode == 0, result.stderr
+        x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
+        assert x_user["identifier"] == machine_id
+
+    def test_installed_script_reports_its_cli_version(self, monkeypatch, tmp_path, hook_server):
         script = tmp_path / "hooks" / "snyk-agent-guard.sh"
-        guard_module._copy_hook_script(script)
+        _copy_with_sentinel_version(monkeypatch, script)
 
         result = subprocess.run(
             ["bash", str(script), "--client", "claude-code"],
@@ -3093,15 +3259,11 @@ class TestBashHookScript:
 
         assert result.returncode == 0, result.stderr
         req = _HookHandler.last_request
-        assert json.loads(req["headers"]["X-User"])["cli_version"] == version_info
-        assert req["headers"]["User-Agent"].endswith(f"Agent Scan v{version_info}")
+        assert json.loads(req["headers"]["X-User"])["cli_version"] == _SENTINEL_VERSION
+        assert req["headers"]["User-Agent"].endswith(f"Agent Scan v{_SENTINEL_VERSION}")
 
     def test_uninstalled_script_reports_an_unknown_cli_version(self, hook_server):
-        """Run from the source tree the placeholder survives -- it must not reach the wire.
-
-        The same holds for a copy written by a CLI that predates a variable: agent-monitor
-        would reject the literal anyway, and an unparseable value is worse than ``unknown``.
-        """
+        """Run from the source tree the placeholder survives -- it must not reach the wire."""
         script = _get_script_path("snyk-agent-guard.sh")
 
         result = subprocess.run(
@@ -3396,9 +3558,38 @@ class TestPowerShellHookScript:
         x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
         assert x_user["identifier"] == "machine-42"
 
-    def test_installed_script_reports_its_cli_version(self, tmp_path, hook_server):
+    def test_machine_id_survives_json_escaping(self, hook_server):
+        """The POSIX contract, pinned on Windows: the identity value round-trips."""
+        script = _get_script_path("snyk-agent-guard.ps1")
+        machine_id = 'DOMAIN\\host"x\tz'
+
+        result = subprocess.run(
+            [
+                self._ps_cmd(),
+                "-File",
+                str(script),
+                "-Client",
+                "claude-code",
+                "-PushKey",
+                "test-pk",
+                "-RemoteUrl",
+                hook_server,
+                "-MachineId",
+                machine_id,
+            ],
+            input='{"hook_event_name":"test","session_id":"s1"}',
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stderr
+        x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
+        assert x_user["identifier"] == machine_id
+
+    def test_installed_script_reports_its_cli_version(self, monkeypatch, tmp_path, hook_server):
         script = tmp_path / "hooks" / "snyk-agent-guard.ps1"
-        guard_module._copy_hook_script(script)
+        _copy_with_sentinel_version(monkeypatch, script)
 
         result = subprocess.run(
             [
@@ -3422,8 +3613,8 @@ class TestPowerShellHookScript:
 
         assert result.returncode == 0, result.stderr
         req = _HookHandler.last_request
-        assert json.loads(req["headers"]["X-User"])["cli_version"] == version_info
-        assert req["headers"]["User-Agent"].endswith(f"Agent Scan v{version_info}")
+        assert json.loads(req["headers"]["X-User"])["cli_version"] == _SENTINEL_VERSION
+        assert req["headers"]["User-Agent"].endswith(f"Agent Scan v{_SENTINEL_VERSION}")
 
     def test_uninstalled_script_reports_an_unknown_cli_version(self, hook_server):
         """The POSIX contract, pinned on Windows: an unsubstituted placeholder never ships."""

--- a/tests/unit/test_guard.py
+++ b/tests/unit/test_guard.py
@@ -3216,29 +3216,6 @@ class TestBashHookScript:
         x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
         assert x_user["identifier"] == "machine-42"
 
-    def test_machine_id_survives_json_escaping(self, hook_server):
-        """The platform keys machine identity on this value, so it must round-trip."""
-        script = _get_script_path("snyk-agent-guard.sh")
-        machine_id = 'DOMAIN\\host"x\tz'
-
-        result = subprocess.run(
-            ["bash", str(script), "--client", "claude-code"],
-            input='{"hook_event_name":"test","session_id":"s1"}',
-            capture_output=True,
-            text=True,
-            timeout=10,
-            env={
-                "PATH": "/usr/bin:/bin:/usr/local/bin",
-                "PUSH_KEY": "test-pk",
-                "REMOTE_HOOKS_BASE_URL": hook_server,
-                "MACHINE_ID": machine_id,
-            },
-        )
-
-        assert result.returncode == 0, result.stderr
-        x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
-        assert x_user["identifier"] == machine_id
-
     def test_installed_script_reports_its_cli_version(self, monkeypatch, tmp_path, hook_server):
         script = tmp_path / "hooks" / "snyk-agent-guard.sh"
         _copy_with_sentinel_version(monkeypatch, script)
@@ -3557,35 +3534,6 @@ class TestPowerShellHookScript:
         assert result.returncode == 0, result.stderr
         x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
         assert x_user["identifier"] == "machine-42"
-
-    def test_machine_id_survives_json_escaping(self, hook_server):
-        """The POSIX contract, pinned on Windows: the identity value round-trips."""
-        script = _get_script_path("snyk-agent-guard.ps1")
-        machine_id = 'DOMAIN\\host"x\tz'
-
-        result = subprocess.run(
-            [
-                self._ps_cmd(),
-                "-File",
-                str(script),
-                "-Client",
-                "claude-code",
-                "-PushKey",
-                "test-pk",
-                "-RemoteUrl",
-                hook_server,
-                "-MachineId",
-                machine_id,
-            ],
-            input='{"hook_event_name":"test","session_id":"s1"}',
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-
-        assert result.returncode == 0, result.stderr
-        x_user = json.loads(_HookHandler.last_request["headers"]["X-User"])
-        assert x_user["identifier"] == machine_id
 
     def test_installed_script_reports_its_cli_version(self, monkeypatch, tmp_path, hook_server):
         script = tmp_path / "hooks" / "snyk-agent-guard.ps1"

--- a/tests/unit/test_hook_events.py
+++ b/tests/unit/test_hook_events.py
@@ -77,6 +77,7 @@ def test_sends_existing_hook_wire_contract(client):
         "hostname": "host-1",
         "username": "user-1",
         "identifier": "machine-1",
+        "cli_version": version_info,
     }
 
 


### PR DESCRIPTION
## What

Sends the agent-scan CLI version as `cli_version` in the `X-User` header on hook events.

agent-monitor has read this field since the MCP-identity work — `GuardrailingContext.get_cli_version()` accepts it if it matches `^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$`, else falls back to `unknown` — and tags four MCP-identity mapping-quality metrics with it. Nothing ever sent one, so every observation was tagged `unknown`. No agent-monitor change is needed to consume this.

> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac54d2afbab39f4c5d5e214eba5e1a25c807ace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

