### PR TITLE
fix: accept Copilot CLI's `type: "local"` for stdio MCP servers

### DIFF
--- a/src/agent_scan/models/mcp.py
+++ b/src/agent_scan/models/mcp.py
@@ -140,6 +140,20 @@ class StdioServer(BaseModel):
     env: dict[str, str] | None = None
     binary_identifier: str | None = None
 
+    @field_validator("type", mode="before")
+    @classmethod
+    def _normalize_transport(cls, v: Any) -> Any:
+        """Fold documented stdio spellings onto ``"stdio"``.
+
+        GitHub Copilot CLI writes ``type: "local"`` for stdio servers in
+        ``~/.copilot/mcp-config.json`` (its transport vocabulary is
+        ``local``/``http``/``sse``). Matching is case-insensitive.
+        """
+        if not isinstance(v, str):
+            return v
+        normalized = v.strip().lower()
+        return "stdio" if normalized == "local" else normalized
+
     @model_validator(mode="after")
     def rebalance_command(self) -> "StdioServer":
         """Rebalance command and args on model creation."""

--- a/tests/unit/test_config_scan.py
+++ b/tests/unit/test_config_scan.py
@@ -424,6 +424,53 @@ class TestHttpUrlAliasParsing:
         )
 
 
+class TestCopilotCLILocalTransport:
+    """GitHub Copilot CLI writes ``type: "local"`` for stdio servers in
+    ``~/.copilot/mcp-config.json``; it must fold onto ``stdio`` rather than
+    sinking the file into ``CouldNotParseMCPConfig``.
+    https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+    """
+
+    @pytest.mark.asyncio
+    async def test_local_type_parses_as_stdio(self, tmp_path):
+        config = tmp_path / "mcp-config.json"
+        # Copied verbatim from the Playwright MCP docs, including the extra
+        # ``tools`` key Copilot CLI accepts.
+        config.write_text("""{
+            "mcpServers": {
+                "playwright": {
+                    "type": "local",
+                    "command": "npx",
+                    "tools": ["*"],
+                    "args": ["@playwright/mcp@latest"]
+                }
+            }
+        }""")
+
+        mcp_config = await scan_mcp_config_file(str(config))
+        servers = mcp_config.get_servers()
+        assert isinstance(servers["playwright"], StdioServer)
+        assert servers["playwright"].type == "stdio"
+        assert servers["playwright"].command == "npx"
+        assert servers["playwright"].args == ["@playwright/mcp@latest"]
+
+    @pytest.mark.asyncio
+    async def test_local_type_does_not_sink_valid_siblings(self, tmp_path):
+        config = tmp_path / "mcp-config.json"
+        config.write_text("""{
+            "mcpServers": {
+                "local-srv": {"type": "local", "command": "npx", "args": ["pkg"]},
+                "remote-srv": {"type": "http", "url": "https://example.com/mcp"}
+            }
+        }""")
+
+        mcp_config = await scan_mcp_config_file(str(config))
+        servers = mcp_config.get_servers()
+        assert len(servers) == 2
+        assert isinstance(servers["local-srv"], StdioServer)
+        assert isinstance(servers["remote-srv"], RemoteServer)
+
+
 class TestPluginMCPConfigFile:
     @pytest.mark.asyncio
     async def test_flat_stdio_server_config(self, tmp_path):


### PR DESCRIPTION
GitHub Copilot CLI writes `"type": "local"` for stdio servers in `~/.copilot/mcp-config.json` (its transport vocabulary is `local`/`http`/`sse`). `StdioServer.type` only accepted `"stdio"`, so such an entry matched neither arm of the `StdioServer | RemoteServer` union and sank the whole `mcpServers` map into `CouldNotParseMCPConfig` — losing every valid sibling server in the file.

Fold `local` onto `stdio` in a before-validator, mirroring the existing `RemoteServer._normalize_transport` fold for `streamable-http`. Other values still fail the `Literal["stdio"]` check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parsing-only change with narrow alias normalization; no runtime connection or auth behavior is modified.
> 
> **Overview**
> **GitHub Copilot CLI** labels stdio MCP entries with **`type: "local"`** in `~/.copilot/mcp-config.json`. The scanner only accepted **`stdio`**, so those entries failed union validation and could **sink the entire `mcpServers` map** (losing valid siblings).
> 
> **`StdioServer`** now normalizes **`local` → `stdio`** in a case-insensitive **before-validator**, matching the existing **`RemoteServer`** transport folding pattern. Extra keys like **`tools`** are ignored; other **`type`** values still fail the **`Literal["stdio"]`** check.
> 
> Unit tests cover a Playwright-style Copilot config and mixed **local** stdio + **http** remote entries in one file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7591b211386517d1448098a52a587ca7e26d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->